### PR TITLE
use 0.6.0-pre as minimum julia version in REQUIRE

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.6-
+julia 0.6.0-pre
 MacroTools
 DataStructures
 Requires


### PR DESCRIPTION
`abstract type` wouldn't work on early 0.6.0-dev versions,
so the package shouldn't claim to support them