### PR TITLE
add option to run twice

### DIFF
--- a/src/tikzdocument.jl
+++ b/src/tikzdocument.jl
@@ -90,8 +90,7 @@ _HAS_WARNED_SHELL_ESCAPE = false
 
 function savepdf(path::String, td::TikzDocument; 
                  latex_engine = latexengine(),
-                 buildflags = vcat(DEFAULT_FLAGS, CUSTOM_FLAGS),
-                 runtwice = false)
+                 buildflags = vcat(DEFAULT_FLAGS, CUSTOM_FLAGS))
     global _HAS_WARNED_SHELL_ESCAPE, _OLD_LUALATEX
     run_again = false
 
@@ -104,9 +103,6 @@ function savepdf(path::String, td::TikzDocument;
     end
 
     log = readstring("$filename.log")
-    rm("$filename.log"; force = true)
-    rm("$filename.aux"; force = true)
-    rm("$filename.tex"; force = true)
 
     if !latex_success
         DEBUG && println("LaTeX command $latexcmd failed")
@@ -138,6 +134,12 @@ function savepdf(path::String, td::TikzDocument;
             error("The latex command $latexcmd failed")
         end
     end
+    if contains(log, "LaTeX Warning: Label(s)")
+        success(latexcmd)
+    end
+    rm("$filename.log"; force = true)
+    rm("$filename.aux"; force = true)
+    rm("$filename.tex"; force = true)
     if run_again
         savepdf(path, td)
         return

--- a/src/tikzdocument.jl
+++ b/src/tikzdocument.jl
@@ -88,8 +88,10 @@ end
 
 _HAS_WARNED_SHELL_ESCAPE = false
 
-function savepdf(path::String, td::TikzDocument; latex_engine = latexengine(),
-                                                     buildflags = vcat(DEFAULT_FLAGS, CUSTOM_FLAGS))
+function savepdf(path::String, td::TikzDocument; 
+                 latex_engine = latexengine(),
+                 buildflags = vcat(DEFAULT_FLAGS, CUSTOM_FLAGS),
+                 runtwice = false)
     global _HAS_WARNED_SHELL_ESCAPE, _OLD_LUALATEX
     run_again = false
 
@@ -97,6 +99,9 @@ function savepdf(path::String, td::TikzDocument; latex_engine = latexengine(),
     savetex(filename, td)
     latexcmd = _latex_cmd(filename, latex_engine, buildflags)
     latex_success = success(latexcmd)
+    if latex_success && runtwice
+        success(latexcmd)
+    end
 
     log = readstring("$filename.log")
     rm("$filename.log"; force = true)


### PR DESCRIPTION
To use the pgf option "legend to name" with \ref, the tex document needs to be compiled twice.
An alternative would be to use latexmk, but I thought this is easier.