### PR TITLE
Reorganize save, add support for standalone extensions.

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,6 @@
 julia 0.6.0-pre
 MacroTools
 DataStructures
+DocStringExtensions
 Requires
 Crayons

--- a/docs/src/man/save.md
+++ b/docs/src/man/save.md
@@ -23,8 +23,9 @@ Figures can be exported to files using
 pgf.save(filename::String, figure; include_preamble::Bool = true, dpi = 150)
 ```
 
-where the file extension of `filename` determines the file type (can be `.pdf`, `.svg` or `.tex`), `include_preamble`
-sets if the preamble should be included in the output (only relevant for `tex` export) and `dpi` determines the dpi of the figure (only relevant for `png` export).
+where the file extension of `filename` determines the file type (can be `.pdf`, `.svg` or `.tex`, or the standalone `tikz` file extensions below), `include_preamble` sets if the preamble should be included in the output (only relevant for `tex` export) and `dpi` determines the dpi of the figure (only relevant for `png` export).
+
+The standalone file extensions `.tikz`, `.TIKZ`, `.TikZ`, `.pgf`, `.PGF` save LaTeX code for a `tikzpicture` environment without a preamble. You can `\input` them directly into a LaTeX document, or use the the [tikzscale](https://www.ctan.org/pkg/tikzscale) LaTeX package for using `\includegraphics` with possible size adjustments.
 
 ## Customizing the preamble
 

--- a/src/PGFPlotsX.jl
+++ b/src/PGFPlotsX.jl
@@ -5,6 +5,7 @@ module PGFPlotsX
 import MacroTools: prewalk, @capture
 
 using DataStructures
+using DocStringExtensions
 using Requires
 
 const DEBUG = haskey(ENV, "PGFPLOTSX_DEBUG")

--- a/src/build.jl
+++ b/src/build.jl
@@ -18,7 +18,7 @@ or an absolute path (recommended). Output files end up in the same directory.
 function _latex_cmd(filename::String, eng::LaTeXEngine, flags)
     dir = splitdir(filename)[1]
     if !isempty(dir)
-        push!(flags, "--output-directory $dir") # works for both engines
+        append!(flags, ["--output-directory", "$dir"]) # works for both engines
     end
     `$(_engine_cmd(eng)) $flags $filename`
 end

--- a/src/build.jl
+++ b/src/build.jl
@@ -9,7 +9,19 @@ latexengine!(eng::LaTeXEngine) = ACTIVE_LATEX_ENGINE[] = eng
 
 _engine_cmd(eng::LaTeXEngine) = `$(lowercase(string(eng)))`
 
-_latex_cmd(file::String, eng::LaTeXEngine, flags) = `$(_engine_cmd(eng)) $flags $file`
+"""
+    $SIGNATURES
+
+Return a `Cmd` object for running LaTeX on `filename`, which can be a relative
+or an absolute path (recommended). Output files end up in the same directory.
+"""
+function _latex_cmd(filename::String, eng::LaTeXEngine, flags)
+    dir = splitdir(filename)[1]
+    if !isempty(dir)
+        push!(flags, "--output-directory $dir") # works for both engines
+    end
+    `$(_engine_cmd(eng)) $flags $filename`
+end
 
 DEFAULT_FLAGS = Union{String}[] # no default flags currently
 CUSTOM_FLAGS = Union{String}[]

--- a/src/tikzdocument.jl
+++ b/src/tikzdocument.jl
@@ -22,43 +22,57 @@ push_preamble!(td::TikzDocument, v) = (push!(td.preamble, v); td)
 # Output #
 ##########
 
-function save(filename::String, td::TikzDocument; include_preamble::Bool = true,
-                                                  latex_engine = latexengine(),
-                                                  buildflags = vcat(DEFAULT_FLAGS, CUSTOM_FLAGS),
-                                                  dpi = 150)
-    file_ending = split(basename(filename), '.')[end]
-    filename_stripped = filename[1:end-4] # This is ugly, whatccha gonna do about it?
-    file_endings = ["tex", "svg", "pdf"]
-    HAVE_PDFTOPPM && push!(file_endings, "png")
-    if !(file_ending in file_endings)
+"""
+Extensions that make [`save`](@ref) choose a standalone `tikz` format.
+
+The saved file has no preamble, just a `tikzpicture` environment. These
+extensions should be recognized by `\includegraphics` when the
+[tikzscale](https://www.ctan.org/pkg/tikzscale) LaTeX package is used.
+"""
+const STANDALONE_TIKZ_FILEEXTS = [".tikz", ".TIKZ", ".TikZ", ".pgf", ".PGF"]
+
+function save(filename::String, td::TikzDocument;
+              include_preamble::Bool = true,
+              latex_engine = latexengine(),
+              buildflags = vcat(DEFAULT_FLAGS, CUSTOM_FLAGS),
+              dpi = 150)
+    filebase, fileext = splitext(filename)
+    if fileext == ".tex"
+        savetex(filename, td; include_preamble = include_preamble)
+    elseif fileext ∈ STANDALONE_TIKZ_FILEEXTS
+        savetex(filename, td; include_preamble = false)
+    elseif fileext == ".svg"
+        savesvg(filebase, td;
+                latex_engine = latex_engine, buildflags = buildflags)
+    elseif fileext == ".pdf"
+        savepdf(filename, td;
+                latex_engine = latex_engine, buildflags = buildflags)
+    elseif HAVE_PDFTOPPM && fileext == ".png"
+        savepng(filebase, td;
+                latex_engine = latex_engine, buildflags = buildflags, dpi = dpi)
+    else
+        allowed_file_endings = vcat(["tex", "svg", "pdf"],
+                                    lstrip.(STANDALONE_TIKZ_FILEEXTS, '.'))
+        if HAVE_PDFTOPPM
+            push!(allowed_file_endings, "png")
+        end
         throw(ArgumentError("allowed file endings are $(join(file_endings, ", "))."))
-    end
-    if file_ending == "tex"
-        savetex(filename_stripped, td; include_preamble = include_preamble)
-    elseif file_ending == "svg"
-        savesvg(filename_stripped, td; latex_engine = latex_engine,
-                                       buildflags = buildflags)
-    elseif file_ending == "pdf"
-        savepdf(filename_stripped, td; latex_engine = latex_engine,
-                                       buildflags = buildflags)
-    elseif file_ending == "png"
-        savepng(filename_stripped, td; latex_engine = latex_engine,
-                                       buildflags = buildflags,
-                                       dpi = dpi)
     end
     return
 end
 
 # TeX
-function savetex(filename::String, td::TikzDocument; include_preamble::Bool = true)
-    open("$(filename).tex", "w") do tex
-        savetex(tex, td; include_preamble = include_preamble)
+function savetex(filename::String, td::TikzDocument;
+                 include_preamble::Bool = true)
+    open(filename, "w") do io
+        savetex(io, td; include_preamble = include_preamble)
     end
 end
 
 _OLD_LUALATEX = false
 
-savetex(io::IO, td::TikzDocument; include_preamble::Bool = true) = print_tex(io, td; include_preamble = include_preamble)
+savetex(io::IO, td::TikzDocument; include_preamble::Bool = true) =
+    print_tex(io, td; include_preamble = include_preamble)
 
 function print_tex(io::IO, td::TikzDocument; include_preamble::Bool = true)
     global _OLD_LUALATEX
@@ -88,20 +102,22 @@ end
 
 _HAS_WARNED_SHELL_ESCAPE = false
 
-function savepdf(path::String, td::TikzDocument; latex_engine = latexengine(),
-                                                     buildflags = vcat(DEFAULT_FLAGS, CUSTOM_FLAGS))
+function savepdf(filename::String, td::TikzDocument;
+                 latex_engine = latexengine(),
+                 buildflags = vcat(DEFAULT_FLAGS, CUSTOM_FLAGS))
     global _HAS_WARNED_SHELL_ESCAPE, _OLD_LUALATEX
     run_again = false
 
-    filename = basename(path)
     savetex(filename, td)
     latexcmd = _latex_cmd(filename, latex_engine, buildflags)
     latex_success = success(latexcmd)
 
-    log = readstring("$filename.log")
-    rm("$filename.log"; force = true)
-    rm("$filename.aux"; force = true)
-    rm("$filename.tex"; force = true)
+    let filebase = splitext(filename)[1]
+        log = readstring("$filebase.log")
+        rm("$filebase.log"; force = true)
+        rm("$filebase.aux"; force = true)
+        rm("$filebase.tex"; force = true)
+    end
 
     if !latex_success
         DEBUG && println("LaTeX command $latexcmd failed")
@@ -134,11 +150,8 @@ function savepdf(path::String, td::TikzDocument; latex_engine = latexengine(),
         end
     end
     if run_again
-        savepdf(path, td)
+        savepdf(filename, td)
         return
-    end
-    if normpath(filename) != normpath(path)
-            mv(filename * ".pdf", joinpath(path * ".pdf"); remove_destination = true)
     end
 end
 
@@ -166,14 +179,14 @@ end
 global _tikzid = round(UInt64, time() * 1e6)
 
 if HAVE_PDFTOSVG
-    function savesvg(filename::String, td::TikzDocument; latex_engine = latexengine(),
+    function savesvg(filebase::String, td::TikzDocument; latex_engine = latexengine(),
                                                          buildflags = vcat(DEFAULT_FLAGS, CUSTOM_FLAGS))
         tmp = tempname()
-        keep_pdf = isfile(filename * ".pdf")
+        keep_pdf = isfile(filebase * ".pdf")
         savepdf(tmp, td, latex_engine = latex_engine, buildflags = buildflags)
         # TODO Better error
-        svg_cmd = `pdf2svg $tmp.pdf $filename.svg`
-        svg_sucess = success(`pdf2svg $tmp.pdf $filename.svg`)
+        svg_cmd = `pdf2svg $tmp.pdf $filebase.svg`
+        svg_sucess = success(`pdf2svg $tmp.pdf $filebase.svg`)
         if !svg_sucess
             error("Failed to run $svg_cmd")
         end
@@ -220,13 +233,13 @@ dpi_juno_png(dpi::Int) = global _JUNO_DPI = dpi
 end
 
 if HAVE_PDFTOPPM
-    function savepng(filename::String, td::TikzDocument; latex_engine = latexengine(),
+    function savepng(filebase::String, td::TikzDocument; latex_engine = latexengine(),
                      buildflags = vcat(DEFAULT_FLAGS, CUSTOM_FLAGS),
                      dpi::Int = 150)
         tmp = tempname()
-        keep_pdf = isfile(filename * ".pdf")
+        keep_pdf = isfile(filebase * ".pdf")
         savepdf(tmp, td, latex_engine = latex_engine, buildflags = buildflags)
-        png_cmd = `pdftoppm -png -r $dpi -singlefile $tmp.pdf $filename`
+        png_cmd = `pdftoppm -png -r $dpi -singlefile $tmp.pdf $filebase`
         png_success = success(png_cmd)
         if !png_success
             error("Error when saving to png")
@@ -249,15 +262,15 @@ _is_juno() = isdefined(Main, :Juno) && Main.Juno.isactive()
 
 function Base.show(io::IO, ::MIME"text/plain", p::_SHOWABLE)
     if isinteractive() && _DISPLAY_PDF && !_is_ijulia() && !_is_juno() && isdefined(Base, :active_repl)
-        f = tempname() .* ".pdf"
-        save(f, p)
+        filename = tempname() .* ".pdf"
+        save(filename, p)
         try
             if is_apple()
-                run(`open $f`)
+                run(`open $filename`)
             elseif is_linux() || is_bsd()
-                run(`xdg-open $f`)
+                run(`xdg-open $filename`)
             elseif is_windows()
-                run(`start $f`)
+                run(`start $filename`)
             end
         catch e
             error("Failed to show the generated pdf, run `PGFPlotsX.enable_interactive(false)` to stop trying to show pdfs.\n", "Error: ", sprint(Base.showerror, e))

--- a/src/tikzdocument.jl
+++ b/src/tikzdocument.jl
@@ -112,12 +112,11 @@ function savepdf(filename::String, td::TikzDocument;
     latexcmd = _latex_cmd(filename, latex_engine, buildflags)
     latex_success = success(latexcmd)
 
-    let filebase = splitext(filename)[1]
-        log = readstring("$filebase.log")
-        rm("$filebase.log"; force = true)
-        rm("$filebase.aux"; force = true)
-        rm("$filebase.tex"; force = true)
-    end
+    filebase = splitext(filename)[1]
+    log = readstring("$filebase.log")
+    rm("$filebase.log"; force = true)
+    rm("$filebase.aux"; force = true)
+    rm("$filebase.tex"; force = true)
 
     if !latex_success
         DEBUG && println("LaTeX command $latexcmd failed")

--- a/src/tikzdocument.jl
+++ b/src/tikzdocument.jl
@@ -48,7 +48,7 @@ function save(filename::String, td::TikzDocument;
         savepdf(filename, td;
                 latex_engine = latex_engine, buildflags = buildflags)
     elseif HAVE_PDFTOPPM && fileext == ".png"
-        savepng(filebase, td;
+        savepng(filename, td;
                 latex_engine = latex_engine, buildflags = buildflags, dpi = dpi)
     else
         allowed_file_endings = vcat(["tex", "svg", "pdf"],
@@ -245,11 +245,12 @@ dpi_juno_png(dpi::Int) = global _JUNO_DPI = dpi
 end
 
 if HAVE_PDFTOPPM
-    function savepng(filebase::String, td::TikzDocument; latex_engine = latexengine(),
+    function savepng(filename::String, td::TikzDocument;
+                     latex_engine = latexengine(),
                      buildflags = vcat(DEFAULT_FLAGS, CUSTOM_FLAGS),
                      dpi::Int = 150)
         tmp = tempname()
-        keep_pdf = isfile(filebase * ".pdf")
+        filebase = splitext(filename)[1]
         savepdf(tmp, td, latex_engine = latex_engine, buildflags = buildflags)
         png_cmd = `pdftoppm -png -r $dpi -singlefile $tmp.pdf $filebase`
         png_success = success(png_cmd)

--- a/src/tikzdocument.jl
+++ b/src/tikzdocument.jl
@@ -108,15 +108,13 @@ function savepdf(filename::String, td::TikzDocument;
     global _HAS_WARNED_SHELL_ESCAPE, _OLD_LUALATEX
     run_again = false
 
-    savetex(filename, td)
-    latexcmd = _latex_cmd(filename, latex_engine, buildflags)
-    latex_success = success(latexcmd)
-
-    filebase = splitext(filename)[1]
-    log = readstring("$filebase.log")
-    rm("$filebase.log"; force = true)
-    rm("$filebase.aux"; force = true)
-    rm("$filebase.tex"; force = true)
+    tmp = tempname()
+    tmp_tex = tmp * ".tex"
+    tmp_pdf = tmp * ".pdf"
+    savetex(tmp_tex, td)
+    latex_success, log, latexcmd = run_latex_once(tmp_tex,
+                                                  latex_engine, buildflags)
+    rm(tmp_tex; force = true)
 
     if !latex_success
         DEBUG && println("LaTeX command $latexcmd failed")
@@ -152,6 +150,7 @@ function savepdf(filename::String, td::TikzDocument;
         savepdf(filename, td)
         return
     end
+    mv(tmp_pdf, filename; remove_destination = true)
 end
 
 const _SHOWABLE = Union{Plot, AbstractVector{Plot}, AxisLike, TikzDocument, TikzPicture}

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -83,3 +83,18 @@ function print_opt(io::IO, t::Tuple)
         i != length(t) && print(io, "}")
     end
 end
+
+"""
+    $SIGNATURES
+
+Replace the extension in `filename` by `ext` (which should include the `.`).
+When the resulting filename is unchanged, throw an error.
+"""
+function _replace_fileext(filename, ext)
+    filebase, fileext = splitext(filename)
+    new_filename = filename * ext
+    if filename == new_filename
+        error("$filename already has extension $ext.")
+    end
+    new_filename
+end

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -92,7 +92,7 @@ When the resulting filename is unchanged, throw an error.
 """
 function _replace_fileext(filename, ext)
     filebase, fileext = splitext(filename)
-    new_filename = filename * ext
+    new_filename = filebase * ext
     if filename == new_filename
         error("$filename already has extension $ext.")
     end

--- a/test/test_build.jl
+++ b/test/test_build.jl
@@ -25,14 +25,15 @@
 end
 
 @testset "simple" begin
+    tmp = tempname()
     mktempdir() do dir
         cd(dir) do
             a = pgf.Axis(pgf.Plot(pgf.Expression("x^2")))
-            pgf.save("texfile.tex", a)
-            println(readstring("texfile.tex"))
-            pgf.save("texfile.pdf", a)
-            pgf.save("texfile.tikz", a)
-            let tikz_lines = readlines("texfile.tikz")
+            pgf.save("$tmp.tex", a)
+            println(readstring("$tmp.tex"))
+            pgf.save("$tmp.pdf", a)
+            pgf.save("$tmp.tikz", a)
+            let tikz_lines = readlines("$tmp.tikz")
                 @test ismatch(r"^\\begin{tikzpicture}.*", tikz_lines[1])
                 last_line = findlast(!isempty, tikz_lines)
                 @test tikz_lines[last_line] == "\\end{tikzpicture}"

--- a/test/test_build.jl
+++ b/test/test_build.jl
@@ -50,7 +50,9 @@ end
             pgf.@pgf p =
                 pgf.Axis(pgf.Plot3(pgf.Expression(expr),
                                    {
-                                       contour_gnuplot = {number = 30, labels = false},
+                                       contour_gnuplot = {
+                                           number = 30,
+                                           labels = false},
                                        thick,
                                        samples = 40,
                                    }; incremental = false),
@@ -65,7 +67,6 @@ end
             pgf.save(tmp_pdf, p)
             @test isfile(tmp_pdf)
             rm(tmp_pdf)
-            end
         end
     end
 end

--- a/test/test_build.jl
+++ b/test/test_build.jl
@@ -25,15 +25,19 @@
 end
 
 @testset "simple" begin
-    a = pgf.Axis(pgf.Plot(pgf.Expression("x^2")))
-    pgf.save("texfile.tex", a)
-    println(readstring("texfile.tex"))
-    pgf.save("texfile.pdf", a)
-    pgf.save("texfile.tikz", a)
-    let tikz_lines = readlines("texfile.tikz")
-        @test ismatch(r"^\\begin{tikzpicture}.*", tikz_lines[1])
-        last_line = findlast(!isempty, tikz_lines)
-        @test tikz_lines[last_line] == "\\end{tikzpicture}"
+    mktempdir() do dir
+        cd(dir) do
+            a = pgf.Axis(pgf.Plot(pgf.Expression("x^2")))
+            pgf.save("texfile.tex", a)
+            println(readstring("texfile.tex"))
+            pgf.save("texfile.pdf", a)
+            pgf.save("texfile.tikz", a)
+            let tikz_lines = readlines("texfile.tikz")
+                @test ismatch(r"^\\begin{tikzpicture}.*", tikz_lines[1])
+                last_line = findlast(!isempty, tikz_lines)
+                @test tikz_lines[last_line] == "\\end{tikzpicture}"
+            end
+        end
     end
 end
 

--- a/test/test_build.jl
+++ b/test/test_build.jl
@@ -43,24 +43,29 @@ end
 end
 
 @testset "gnuplot / shell-escape" begin
-    pgf.@pgf p = pgf.Axis(pgf.Plot3(pgf.Expression("-2.051^3*1000./(2*3.1415*(2.99*10^2)^2)/(x^2*cos(y)^2)"),
-            {
-                contour_gnuplot = {number = 30, labels = false},
-                thick,
-                samples = 40,
-            }; incremental = false),
-        {
-            colorbar,
-            xlabel = "x",
-            ylabel = "y",
-            domain = 1:2,
-            y_domain = "74:87.9",
-            view = (0, 90),
-        })
-        cd(tempdir()) do
-            file = "gnuplot.pdf"
-            pgf.save(file, p)
-            @test isfile(file)
-            rm(file)
+    tmp_pdf = tempname() * ".pdf"
+    expr = "-2.051^3*1000./(2*3.1415*(2.99*10^2)^2)/(x^2*cos(y)^2)"
+    mktempdir() do dir
+        cd(dir) do
+            pgf.@pgf p =
+                pgf.Axis(pgf.Plot3(pgf.Expression(expr),
+                                   {
+                                       contour_gnuplot = {number = 30, labels = false},
+                                       thick,
+                                       samples = 40,
+                                   }; incremental = false),
+                         {
+                             colorbar,
+                             xlabel = "x",
+                             ylabel = "y",
+                             domain = 1:2,
+                             y_domain = "74:87.9",
+                             view = (0, 90),
+                         })
+            pgf.save(tmp_pdf, p)
+            @test isfile(tmp_pdf)
+            rm(tmp_pdf)
+            end
         end
+    end
 end

--- a/test/test_build.jl
+++ b/test/test_build.jl
@@ -29,6 +29,12 @@ end
     pgf.save("texfile.tex", a)
     println(readstring("texfile.tex"))
     pgf.save("texfile.pdf", a)
+    pgf.save("texfile.tikz", a)
+    let tikz_lines = readlines("texfile.tikz")
+        @test ismatch(r"^\\begin{tikzpicture}.*", tikz_lines[1])
+        last_line = findlast(!isempty, tikz_lines)
+        @test tikz_lines[last_line] == "\\end{tikzpicture}"
+    end
 end
 
 @testset "gnuplot / shell-escape" begin


### PR DESCRIPTION
Fixes #24. Also,

1. document some internals (using DocStringExtensions, hope that's OK),

2. consistent use of variables for paths: `filename` with and `filebase` without extensions,

3. specify `--output-directory` for the latex engine so all files end up in the right place,

4. added some tests for standalone formats.