### PR TITLE
Rework coordinates.

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,7 +1,9 @@
 julia 0.6
+ArgCheck
 MacroTools
 Compat
 DataStructures
 DocStringExtensions
+Parameters
 Requires
 Crayons

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -17,6 +17,7 @@ makedocs(
             "man/custom_types.md",
             ],
         "Examples" => [
+            "examples/coordinates.md",
             "examples/gallery.md",
             "examples/juliatypes.md"
         ]

--- a/docs/src/examples/coordinates.md
+++ b/docs/src/examples/coordinates.md
@@ -1,0 +1,90 @@
+# Coordinates
+
+```jl
+import PGFPlotsX
+const pgf = PGFPlotsX; # hide
+using LaTeXStrings
+```
+
+```@setup pgf
+import PGFPlotsX
+const pgf = PGFPlotsX
+using LaTeXStrings
+savefigs = (figname, obj) -> begin
+    pgf.save(figname * ".pdf", obj)
+    run(`pdf2svg $(figname * ".pdf") $(figname * ".svg")`)
+    pgf.save(figname * ".tex", obj);
+    return nothing
+end
+```
+
+Use `Coordinates` to construct the `pgfplots` construct `coordinates`. Various constructors are available.
+
+For basic usage, consider `AbstractVectors` and iterables. Notice how non-finite values are skipped. You can also use `()` or `nothing` for jumps in functions.
+
+```@example pgf
+x = linspace(-1, 1, 51) # so that it contains 1/0
+pgf.@pgf pgf.Axis(pgf.Plot(pgf.Coordinates(x, 1 ./ x), { "no marks" }),
+                  { xmajorgrids, ymajorgrids })
+savefigs("coordinates-simple", ans) # hide
+```
+
+[\[.pdf\]](coordinates-simple.pdf), [\[generated .tex\]](coordinates-simple.tex)
+
+![](coordinates-simple.svg)
+
+Use `xerror`, `xerrorplus`, `xerrorminus`, `yerror` etc for error bars.
+```@example pgf
+x = linspace(0, 2π, 20)
+pgf.Plot(pgf.Coordinates(x, sin.(x); yerror = 0.2*cos.(x)),
+         pgf.@pgf { "no marks",
+                    "error bars/y dir=both",
+                    "error bars/y explicit" })
+savefigs("coordinates-errorbars", ans) # hide
+```
+
+[\[.pdf\]](coordinates-errorbars.pdf), [\[generated .tex\]](coordinates-errorbars.tex)
+
+![](coordinates-errorbars.svg)
+
+Use three vectors to construct 3D coordinates.
+
+```@example pgf
+t = linspace(0, 6*π, 100)
+pgf.@pgf pgf.Plot3(pgf.Coordinates(t .* sin.(t), t .* cos.(t), .-t),
+                   { "no marks" })
+savefigs("coordinates-3d", ans) # hide
+```
+
+[\[.pdf\]](coordinates-3d.pdf), [\[generated .tex\]](coordinates-3d.tex)
+
+![](coordinates-3d.svg)
+
+A convenience constructor is available for plotting a matrix of values calculated from edge vectors.
+
+```@example pgf
+x = linspace(-2, 2, 20)
+y = linspace(-0.5, 3, 25)
+f(x, y) = (1 - x)^2 + 100*(y - x^2)^2
+pgf.Plot3(pgf.Coordinates(x, y, f.(x, y')), pgf.@pgf { surf };
+          incremental = false)
+savefigs("coordinates-3d-matrix", ans) # hide
+```
+
+[\[.pdf\]](coordinates-3d-matrix.pdf), [\[generated .tex\]](coordinates-3d-matrix.tex)
+
+![](coordinates-3d-matrix.svg)
+
+```@example pgf
+x = linspace(-2, 2, 40)
+y = linspace(-0.5, 3, 50)
+pgf.@pgf pgf.Axis(pgf.Plot3(pgf.Coordinates(x, y, @. √(f(x, y'))),
+                            { surf, shader = "flat" };
+                            incremental = false),
+                  { view = "{0}{90}", colorbar, "colormap/jet" })
+savefigs("coordinates-3d-matrix-heatmap", ans) # hide
+```
+
+[\[.pdf\]](coordinates-3d-matrix-heatmap.pdf), [\[generated .tex\]](coordinates-3d-matrix-heatmap.tex)
+
+![](coordinates-3d-matrix-heatmap.svg)

--- a/docs/src/examples/coordinates.md
+++ b/docs/src/examples/coordinates.md
@@ -2,7 +2,7 @@
 
 ```jl
 import PGFPlotsX
-const pgf = PGFPlotsX; # hide
+const pgf = PGFPlotsX
 using LaTeXStrings
 ```
 
@@ -24,8 +24,18 @@ For basic usage, consider `AbstractVectors` and iterables. Notice how non-finite
 
 ```@example pgf
 x = linspace(-1, 1, 51) # so that it contains 1/0
-pgf.@pgf pgf.Axis(pgf.Plot(pgf.Coordinates(x, 1 ./ x), { "no marks" }),
-                  { xmajorgrids, ymajorgrids })
+pgf.@pgf pgf.Axis(
+    {
+        xmajorgrids,
+        ymajorgrids,
+    },
+    pgf.Plot(
+        {
+            no_marks,
+        },
+        pgf.Coordinates(x, 1 ./ x)
+    )
+)
 savefigs("coordinates-simple", ans) # hide
 ```
 
@@ -36,10 +46,14 @@ savefigs("coordinates-simple", ans) # hide
 Use `xerror`, `xerrorplus`, `xerrorminus`, `yerror` etc for error bars.
 ```@example pgf
 x = linspace(0, 2π, 20)
-pgf.Plot(pgf.Coordinates(x, sin.(x); yerror = 0.2*cos.(x)),
-         pgf.@pgf { "no marks",
-                    "error bars/y dir=both",
-                    "error bars/y explicit" })
+pgf.@pgf pgf.Plot(
+    {
+        "no marks",
+        "error bars/y dir=both",
+        "error bars/y explicit",
+    },
+    pgf.Coordinates(x, sin.(x); yerror = 0.2*cos.(x))
+)
 savefigs("coordinates-errorbars", ans) # hide
 ```
 
@@ -51,8 +65,12 @@ Use three vectors to construct 3D coordinates.
 
 ```@example pgf
 t = linspace(0, 6*π, 100)
-pgf.@pgf pgf.Plot3(pgf.Coordinates(t .* sin.(t), t .* cos.(t), .-t),
-                   { "no marks" })
+pgf.@pgf pgf.Plot3(
+    {
+        no_marks,
+    },
+    pgf.Coordinates(t .* sin.(t), t .* cos.(t), .-t)
+)
 savefigs("coordinates-3d", ans) # hide
 ```
 
@@ -66,8 +84,13 @@ A convenience constructor is available for plotting a matrix of values calculate
 x = linspace(-2, 2, 20)
 y = linspace(-0.5, 3, 25)
 f(x, y) = (1 - x)^2 + 100*(y - x^2)^2
-pgf.Plot3(pgf.Coordinates(x, y, f.(x, y')), pgf.@pgf { surf };
-          incremental = false)
+pgf.@pgf pgf.Plot3(
+    {
+        surf,
+    },
+    pgf.Coordinates(x, y, f.(x, y'));
+    incremental = false
+)
 savefigs("coordinates-3d-matrix", ans) # hide
 ```
 
@@ -78,10 +101,21 @@ savefigs("coordinates-3d-matrix", ans) # hide
 ```@example pgf
 x = linspace(-2, 2, 40)
 y = linspace(-0.5, 3, 50)
-pgf.@pgf pgf.Axis(pgf.Plot3(pgf.Coordinates(x, y, @. √(f(x, y'))),
-                            { surf, shader = "flat" };
-                            incremental = false),
-                  { view = "{0}{90}", colorbar, "colormap/jet" })
+pgf.@pgf pgf.Axis(
+    {
+        view = (0, 90),
+        colorbar,
+        "colormap/jet",
+    },
+    pgf.Plot3(
+        {
+            surf,
+            shader = "flat",
+        },
+        pgf.Coordinates(x, y, @. √(f(x, y')));
+        incremental = false
+    )
+)
 savefigs("coordinates-3d-matrix-heatmap", ans) # hide
 ```
 

--- a/docs/src/examples/gallery.md
+++ b/docs/src/examples/gallery.md
@@ -5,7 +5,7 @@ This is a work in progress. All the examples are run with the following code add
 
 ```jl
 import PGFPlotsX
-const pgf = PGFPlotsX; # hide
+const pgf = PGFPlotsX
 using LaTeXStrings
 ```
 

--- a/docs/src/examples/juliatypes.md
+++ b/docs/src/examples/juliatypes.md
@@ -5,7 +5,7 @@ All code is assumed to include the following:
 
 ```jl
 import PGFPlotsX
-const pgf = PGFPlotsX; # hide
+const pgf = PGFPlotsX
 using LaTeXStrings
 ```
 

--- a/src/PGFPlotsX.jl
+++ b/src/PGFPlotsX.jl
@@ -4,10 +4,12 @@ module PGFPlotsX
 
 import MacroTools: prewalk, @capture
 
+using ArgCheck
 using Compat
 using Compat.Unicode            # for lowercase
 using DataStructures
 using DocStringExtensions
+using Parameters
 using Requires
 
 const DEBUG = haskey(ENV, "PGFPLOTSX_DEBUG")

--- a/src/requires.jl
+++ b/src/requires.jl
@@ -63,4 +63,10 @@ end
         end
         println(io, edge[end], "    ", 0)
     end
+
+    function PGFPlotsX.Coordinates(histogram::StatsBase.Histogram{T, 2}) where T
+        PGFPlotsX.Coordinates(midpoints(histogram.edges[1]),
+                              midpoints(histogram.edges[2]),
+                              histogram.weights)
+    end
 end

--- a/test/test_elements.jl
+++ b/test/test_elements.jl
@@ -28,3 +28,46 @@ squashed_repr_tex(args...) = squash_whitespace(repr_tex(args...))
     @test squashed_repr_tex(string.([2, 3, 4])) == "2\n3\n4"
     @test_throws ArgumentError repr_tex(4) # undefined
 end
+
+@testset "coordinate" begin
+    @test_throws ArgumentError pgf.Coordinate((1, ))    # dimension not 2 or 3
+    @test_throws ArgumentError pgf.Coordinate((NaN, 1)) # not finite
+    @test_throws ArgumentError pgf.Coordinate((1, 2);   # can't specify both
+                                              error = (0, 0), errorplus = (0, 0))
+    @test_throws MethodError pgf.Coordinates((1, 2); error = (3, )) # incompatible dims
+    @test squashed_repr_tex(pgf.Coordinate((1, 2))) == "(1, 2)"
+    @test squashed_repr_tex(pgf.Coordinate((1, 2); error = (3, 4))) == "(1, 2) +- (3, 4)"
+    @test squashed_repr_tex(pgf.Coordinate((1, 2); errorminus = (3, 4))) ==
+        "(1, 2) -= (3, 4)"
+    @test squashed_repr_tex(pgf.Coordinate((1, 2);
+                                           errorminus = (3, 4),
+                                           errorplus = (5, 6))) ==
+                                               "(1, 2) += (5, 6) -= (3, 4)"
+    @test squashed_repr_tex(pgf.Coordinate((1, 2); meta = "blue")) == "(1, 2) [blue]"
+end
+
+@testset "coordinates and convenience constructors" begin
+    @test_throws ArgumentError pgf.Coordinates([(1, 2), (1, 2, 3)]) # incompatible dims
+    @test_throws ArgumentError pgf.Coordinates([(1, 2), "invalid"]) # invalid value
+
+    # from Vectors and AbstractVectors
+    @test pgf.Coordinates([1, 2], [3.0, 4.0]).data == pgf.Coordinate.([(1, 3.0), (2, 4.0)])
+    @test pgf.Coordinates(1:2, 3:4).data == pgf.Coordinate.([(1, 3), (2, 4)])
+    # skip empty
+    @test pgf.Coordinates([(2, 3), (), nothing]).data ==
+        [pgf.Coordinate((2, 3)), pgf.EmptyLine(), pgf.EmptyLine()]
+    @test pgf.Coordinates(1:2, 3:4, (1:2)./((3:4)')).data ==
+        pgf.Coordinates(Any[1, 2, NaN, 1, 2, NaN],
+                        Any[3, 3, NaN, 4, 4, NaN],
+                        Any[1/3, 2/3, NaN, 1/4, 2/4, NaN]).data
+    # from iterables
+    @test pgf.Coordinates(enumerate(3:4)).data == pgf.Coordinate.([(1, 3), (2, 4)])
+    @test pgf.Coordinates((x, 1/x) for x in -1:1).data ==
+        [pgf.Coordinate((-1, -1.0)), pgf.EmptyLine(), pgf.Coordinate((1, 1.0))]
+    let x = 1:3,
+        y = -1:1,
+        z = x ./ y
+        @test pgf.Coordinates(x, y, z).data ==
+            pgf.Coordinates((x, y, x / y) for (x,y) in zip(x, y)).data
+    end
+end


### PR DESCRIPTION
This is a step towards fixing #44, and is in accordance with the
principles laid out there, but not the exact syntax proposed there
since it was found to be impractical. Also fixes #11.

1. Introduce the `Coordinate` type for individual coordinates. Validate
arguments and fail early.

2. Introduce `EmptyLine` for jumps/scanlines. This addresses #11.

3. Rewrite `Coordinates` to contain the above. (`<: OptionType` was
removed, because it has no options).

4. Convenience constructors for creating coordinates from vectors,
matrices, iterable objects, with or without error bars. Docstrings for
the API.

5. Add examples of all the new syntax to the gallery (some of this
should be moved to the documentation eventually, that will come later
after other changes).

6. 2D histograms now work (example will be added later, when `Table`
are redesigned similarly).