### PR TITLE
Change constructor syntax for TikzDocument and TikzPicture.

### DIFF
--- a/docs/src/examples/juliatypes.md
+++ b/docs/src/examples/juliatypes.md
@@ -60,7 +60,7 @@ for cmap in colormaps
     push_preamble!(td, (cmap, Colors.colormap(cmap)))
 end
 
-tp = TikzPicture("scale" => 0.5)
+tp = @pgf TikzPicture({ "scale" => 0.5 })
 push!(td, tp)
 gp = @pgf GroupPlot({ group_style = {group_size = "2 by 2"}})
 push!(tp, gp)

--- a/docs/src/man/structs.md
+++ b/docs/src/man/structs.md
@@ -355,6 +355,8 @@ Hello World
 \end{document}
 ```
 
+A `TikzDocument` uses global variables to construct a preamble, and allows the user to add extra lines to this (eg in case you want to add `\usepackage` lines), or disable it altogether.
+
 !!! note
 
     There is usually no need to explicitly create a `TikzDocument` or `TikzPicture`.

--- a/src/tikzpicture.jl
+++ b/src/tikzpicture.jl
@@ -1,27 +1,29 @@
 const TikzElementOrStr = Union{TikzElement, String}
 
+"""
+    TikzPicture([options], contents...)
+
+Corredponds to a `tikzpicture` block in `pgfplots`.
+
+Elements can also be added with `push!` after contruction.
+"""
 struct TikzPicture <: OptionType
-    elements::Vector{TikzElementOrStr} # Plots, nodes etc
     options::Options
+    elements::Vector{TikzElementOrStr} # Plots, nodes etc
+    function TikzPicture(options::Options, elements::TikzElementOrStr...)
+        new(options, collect(TikzElementOrStr, elements))
+    end
 end
 
-function TikzPicture(options::Vararg{PGFOption})
-    TikzPicture(TikzElementOrStr[], dictify(options))
-end
-
-TikzPicture(element::TikzElementOrStr, args...) = TikzPicture([element], args...)
-TikzPicture(options::Options, element::TikzElementOrStr) = TikzPicture(element, options)
-
-function TikzPicture(elements::Vector, options::Vararg{PGFOption})
-    TikzPicture(convert(Vector{TikzElementOrStr}, elements), dictify(options))
-end
+TikzPicture(elements::TikzElementOrStr...) = TikzPicture(Options(), elements...)
 
 Base.push!(tp::TikzPicture, element::TikzElementOrStr) = push!(tp.elements, element)
 
 function print_tex(io::IO, tp::TikzPicture)
+    @unpack options, elements = tp
     print(io, "\\begin{tikzpicture}")
-    print_options(io, tp.options)
-    for element in tp.elements
+    print_options(io, options)
+    for element in elements
         print_tex(io, element, tp)
     end
     println(io, "\\end{tikzpicture}")


### PR DESCRIPTION
This completes and closed #44.

`TikzPicture([options], elements...)` is the new syntax, consistently with the other `OptionType`s. Fix examples in documentation.

`TikzDocument(elements...; ...)` is the new syntax. The default preamble is obtained dynamically from the global variables, not at the time of construction as before.