### PR TITLE
Consistency of push! and append! methods.

### DIFF
--- a/src/axiselements.jl
+++ b/src/axiselements.jl
@@ -498,8 +498,8 @@ end
 Plot(is3d::Bool, incremental::Bool, options::Options, data::PlotData,
      trailing::Tuple) = Plot(is3d, incremental, options, data, collect(trailing))
 
-Base.push!(plot::Plot, element) = (push!(plot.trailing, element); plot)
-Base.append!(plot::Plot, element) = (append!(plot.trailing, element); plot)
+Base.push!(plot::Plot, items...) = (push!(plot.trailing, items...); plot)
+Base.append!(plot::Plot, items) = (append!(plot.trailing, items); plot)
 
 """
     Plot([options::Options], data, trailing...)

--- a/src/axislike.jl
+++ b/src/axislike.jl
@@ -21,8 +21,8 @@ Return the corresponding LaTeX environment name.
 """
 function axislike_environment end
 
-Base.push!(axislike::AxisLike, elt) = (push!(axislike.contents, elt); axislike)
-Base.append!(axislike::AxisLike, elt) = (append!(axislike.contents, elt); axislike)
+Base.push!(axislike::AxisLike, items...) = (push!(axislike.contents, items...); axislike)
+Base.append!(axislike::AxisLike, items) = (append!(axislike.contents, items); axislike)
 
 (T::Type{<:AxisLike})(contents...) = T(Options(), contents...)
 

--- a/src/tikzdocument.jl
+++ b/src/tikzdocument.jl
@@ -22,7 +22,8 @@ struct TikzDocument
     end
 end
 
-Base.push!(td::TikzDocument, v) = (push!(td.elements, v); td)
+Base.push!(td::TikzDocument, items...) = (push!(td.elements, items...); td)
+Base.append!(td::TikzDocument, items) = (append!(td.elements, items); td)
 
 """
     $SIGNATURES

--- a/src/tikzpicture.jl
+++ b/src/tikzpicture.jl
@@ -17,7 +17,8 @@ end
 
 TikzPicture(elements::TikzElementOrStr...) = TikzPicture(Options(), elements...)
 
-Base.push!(tp::TikzPicture, element::TikzElementOrStr) = push!(tp.elements, element)
+Base.push!(tp::TikzPicture, items::TikzElementOrStr...) = push!(tp.elements, items...)
+Base.append!(tp::TikzPicture, items::TikzElementOrStr) = append!(tp.elements, items)
 
 function print_tex(io::IO, tp::TikzPicture)
     @unpack options, elements = tp


### PR DESCRIPTION
(Housekeeping, in preparation for the release. Traits would unify a bit of code, left for future work).

1. Make `push!` methods accept multiple items (similarly to `Base`),

2. consistent argument naming,

3. some `append!` methods were missing.