### PR TITLE
Make row separator \\ the default for tables.

### DIFF
--- a/docs/src/examples/gallery.md
+++ b/docs/src/examples/gallery.md
@@ -1,4 +1,4 @@
-# PGFPlots manual gallery
+# [PGFPlots manual gallery](@id manual_gallery)
 
 Examples converted from [the PGFPlots manual gallery](http://pgfplots.sourceforge.net/gallery.html).
 This is a work in progress.
@@ -343,18 +343,15 @@ savefigs("groupplot-nested", ans) # hide
         "table/row sep" = raw"\\",
         patch_table = TableData([0 1 2;
                                  1 2 3;
-                                 4 3 5];
-                                rowsep = true)
+                                 4 3 5])
     },
     Table(
         {
-            row_sep = raw"\\",
             point_meta = raw"\thisrow{c}"
         },
         :x => [0, 1, 2, 3, 2, 4],
         :y => [0, 1, 0, 1, 0, 0],
-        :c => [0.2, 0, 1, 0, 0.5, 0.5];
-        rowsep = true)))
+        :c => [0.2, 0, 1, 0, 0.5, 0.5])))
 
 savefigs("patch-inline", ans) # hide
 ```

--- a/docs/src/man/data.md
+++ b/docs/src/man/data.md
@@ -37,16 +37,20 @@ julia> t = @pgf Table({x => "Dof", y => "Err"},
                       [:Dof => [1, 2, 4], :Err => [2.0, 1.0, 0.1]]);
 
 julia> print_tex(t)
-table[x={Dof}, y={Err}]
+table[row sep={\\}, x={Dof}, y={Err}]
 {
-    Dof  Err
-    1.0  2.0
-    2.0  1.0
-    4.0  0.1
+    Dof  Err  \\
+    1.0  2.0  \\
+    2.0  1.0  \\
+    4.0  0.1  \\
 }
 ```
 
 If you load the DataFrames package, you can also create tables from data frames, see the examples in [Julia types](@ref).
+
+!!! note
+
+    By default, PGFPlots expects rows to be separated in a table with a newline. This can be “fragile” in LaTeX, in the sense that linebreaks may be merged with other whitespace within certain constructs, eg macros. In order to prevent this, this package uses the option `rowsep=\\` by default. This is taken care of automatically, except for inline tables where you have to specify it manually. See the `patch` plot in the [gallery](@ref manual_gallery).
 
 ## [Coordinates](@id coordinates_header)
 

--- a/src/axiselements.jl
+++ b/src/axiselements.jl
@@ -282,7 +282,7 @@ expand_scanlines(itr, _) = collect(Int, itr)
 
 
 "Default for additional row separator `\\`."
-const ROWSEP = false
+const ROWSEP = true
 
 """
 Tabular data with optional column names.
@@ -296,7 +296,15 @@ after `options`.
 printed using `print_tex`. `colnames` is a vector of column names (converted to
 string), or `nothing` for a table with no column names.
 
-When `rowsep` is `true`, an additional `\\\\` is used as a row separator.
+When `rowsep` is `true`, an additional `\\\\` is used as a row separator. The
+default is `true`, this is recommended to avoid “fragility” issues with inline
+tables.
+
+!!! note
+
+    `Table` queries `TableData` for its `rowsep`, and adds the relevant option
+    accordingly. When using “inline” tables, eg in options, you have to specify
+    this manually for the container. See the gallery for examples.
 
 After each index in `scanlines`, extra row separators are inserted. This can be
 used for skipping coordinates or implicitly defining the dimensions of a matrix
@@ -453,10 +461,20 @@ Table(options::Options, args...; kwargs...) =
 
 Table(args...; kwargs...) = Table(Options(), args...; kwargs...)
 
+"""
+    $SIGNATURES
+
+Options to mix in for the container. Currently used for `TableData` and `Table`.
+"""
+container_options(tabledata::TableData, ::Table) =
+    Options("row sep" => tabledata.rowsep ? raw"\\" : "newline")
+
+container_options(::AbstractString, ::Table) = Options() # included from file
+
 function print_tex(io::IO, table::Table)
     @unpack options, content = table
     print(io, "table")
-    print_options(io, options)
+    print_options(io, merge(container_options(content, table), options))
     println(io, "{")
     print_indent(io, content)
     println(io, "}")

--- a/test/test_elements.jl
+++ b/test/test_elements.jl
@@ -127,7 +127,7 @@ end
                                       [1 NaN;
                                        -Inf 4.0],
                                       ["xx", "yy"],
-                                      [1])) == "table[]\n{\nxx yy\n1.0 nan\n\n-inf 4.0\n}"
+                                      [1])) == "table[row sep={\\\\}]\n{\nxx yy \\\\\n1.0 nan \\\\\n\\\\\n-inf 4.0 \\\\\n}"
 end
 
 @testset "table file" begin
@@ -142,7 +142,7 @@ end
     data2 = Table(x = 1:2, y = 3:4)
     p2 = Plot(false, false, PGFPlotsX.Options(), data2, [raw"\closedcycle"])
     @test squashed_repr_tex(p2) ==
-        "\\addplot[]\ntable[]\n{\nx y\n1 3\n2 4\n}\n\\closedcycle\n;"
+        "\\addplot[]\ntable[row sep={\\\\}]\n{\nx y \\\\\n1 3 \\\\\n2 4 \\\\\n}\n\\closedcycle\n;"
     @test Plot(@pgf({}), data2, raw"\closedcycle") ≅ p2
     @test PlotInc(@pgf({}), data2, raw"\closedcycle") ≅
         Plot(false, true, PGFPlotsX.Options(), data2, [raw"\closedcycle"])
@@ -151,10 +151,10 @@ end
     @test Plot(data2, raw"\closedcycle") ≅ p2
     # printing incremental w/ options, 2D and 3D
     @test squashed_repr_tex(PlotInc(data2)) ==
-        "\\addplot+[]\ntable[]\n{\nx y\n1 3\n2 4\n}\n;"
+        "\\addplot+[]\ntable[row sep={\\\\}]\n{\nx y \\\\\n1 3 \\\\\n2 4 \\\\\n}\n;"
     @test squashed_repr_tex(@pgf Plot3Inc({xtick = 1:3},
                                           Table(x = 1:2, y = 3:4, z = 5:6))) ==
-        "\\addplot3+[xtick={1,2,3}]\ntable[]\n{\nx y z\n1 3 5\n2 4 6\n}\n;"
+        "\\addplot3+[xtick={1,2,3}]\ntable[row sep={\\\\}]\n{\nx y z \\\\\n1 3 5 \\\\\n2 4 6 \\\\\n}\n;"
 end
 
 @testset "printing and indentation" begin
@@ -174,12 +174,12 @@ end
     c = Coordinates([(1, 2), (3, 4)])
     @test repr_tex(c) == "coordinates {\n    (1, 2)\n    (3, 4)\n}\n"
     t = Table(x = 1:2, y = 3:4)
-    @test repr_tex(t) == "table[]\n{\n    x  y  \n    1  3  \n    2  4  \n}\n"
+    @test repr_tex(t) == "table[row sep={\\\\}]\n{\n    x  y  \\\\\n    1  3  \\\\\n    2  4  \\\\\n}\n"
     @test repr_tex(@pgf Plot({ no_marks }, c)) ==
         "\\addplot[no marks]\n    coordinates {\n        (1, 2)\n        (3, 4)\n    }\n    ;\n"
     @test repr_tex(@pgf Plot({ no_marks }, t, "trailing")) ==
-        "\\addplot[no marks]\n    table[]\n    {\n        x  y  \n" *
-        "        1  3  \n        2  4  \n    }\n    trailing\n    ;\n"
+        "\\addplot[no marks]\n    table[row sep={\\\\}]\n    {\n        x  y  \\\\\n" *
+        "        1  3  \\\\\n        2  4  \\\\\n    }\n    trailing\n    ;\n"
     # legend
     @test repr_tex(Legend(["a", "b", "c"])) == "\\legend{a, b, c}\n"
     l = LegendEntry("a")


### PR DESCRIPTION
Closes #79.

`Table`s now use `\\` depending on `TableData` for inline data as necessary. Tables from files are not affected.

The “patch” example is somewhat simplified. 

Manual is extended accordingly.

`container_options` implements this extensibly (in case other types need it, but I don't see an immediate use).