### PR TITLE
Ijulia fixes

### DIFF
--- a/docs/src/man/save.md
+++ b/docs/src/man/save.md
@@ -6,7 +6,10 @@ Figures are shown in `svg` format when evaluated in Jupyter. For this you need t
 
 ## Juno
 
-Figures are shown in the Juno plot pane as `svg`s by default. If you want to show them as `png`, run `show_juno_png(true)`, (`false` to go back to `svg`). To set the dpi of the figures in Juno when using `png`, run `dpi_juno_png(dpi::Int)`
+Figures are shown in the Juno plot pane as `svg`s by default. If you want to show them as `png`, run `show_juno_png(true)`, (`false` to go back to `svg`).
+To set the dpi of the figures in Juno when using `png`, run `dpi_juno_png(dpi::Int)`.
+If you are on macOS and there are problems finding the latex executable, see [this isssue](https://github.com/atom/atom/issues/6956).
+Starting Atom through the terminal seems to work around it.
 
 ## REPL
 

--- a/src/tikzdocument.jl
+++ b/src/tikzdocument.jl
@@ -172,6 +172,7 @@ function savepdf(filename::String, td::TikzDocument;
                 DEBUG && println("Adding shell-escape and trying to save pdf again")
                 # Try again with enabling shell_escape
                 push!(DEFAULT_FLAGS, shell_escape)
+                push!(buildflags, shell_escape)
                 run_again = true
             else
                 latexerrormsg(log)

--- a/src/tikzdocument.jl
+++ b/src/tikzdocument.jl
@@ -135,7 +135,8 @@ _HAS_WARNED_SHELL_ESCAPE = false
 
 function savepdf(filename::String, td::TikzDocument;
                  latex_engine = latexengine(),
-                 buildflags = vcat(DEFAULT_FLAGS, CUSTOM_FLAGS))
+                 buildflags = vcat(DEFAULT_FLAGS, CUSTOM_FLAGS),
+                 run_count = 0)
     global _HAS_WARNED_SHELL_ESCAPE, _OLD_LUALATEX
     run_again = false
 
@@ -177,8 +178,12 @@ function savepdf(filename::String, td::TikzDocument;
             error("The latex command $latexcmd failed")
         end
     end
+    run_again = run_again || contains(log, "LaTeX Warning: Label(s) may have changed")
+    if run_again && run_count == 4
+        error("ran latex 5 times without converging, log is:\n$log")
+    end
     if run_again
-        savepdf(filename, td)
+        savepdf(filename, td; latex_engine=latex_engine, buildflag=buildflags, run_count=run_count+1)
         return
     end
     mv(tmp_pdf, filename; remove_destination = true)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,9 +19,9 @@ include("test_macros.jl")
 
 include("test_elements.jl")
 
-cd(tempdir()) do
+mktempdir() do tmp; cd(tmp) do
     include("test_build.jl")
-end
+end end
 
 include("../docs/make.jl")
 


### PR DESCRIPTION
- rerun latex if we have labels that needs changing
- prevents a possible infinite loop
- prevents ijulia from running latex twice on every figure