### PR TITLE
Silence warnings for empty groupplots

### DIFF
--- a/src/axislike.jl
+++ b/src/axislike.jl
@@ -120,7 +120,7 @@ function print_tex(io::IO, groupplot::GroupPlot)
             elseif elt isa Plot
                 print_tex(io, elt)
             elseif elt isa Void
-                print(io, raw"\nextgroupplot[group/empty plot]")
+                println(io, raw"\nextgroupplot[group/empty plot,xmin=0,xmax=1,ymin=0,ymax=1]")
             else
                 print_tex(io, elt)
             end


### PR DESCRIPTION
Silence the following warnings for empty groupplots
```
You have an axis with empty range (in direction y). Replacing it with a default range and clearing all plots
You have an axis with empty range (in direction x). Replacing it with a default range and clearing all plots
```
by printing `nothing` as `\nextgroupplot[group/empty plot,xmin=0,xmax=1,ymin=0,ymax=1]`.
Also adds a newline after the empty plot in the printed tex.