### PR TITLE
Require at-pgf {"group/empty plot"} in GroupPlot instead of using nothing.

### DIFF
--- a/docs/src/examples/gallery.md
+++ b/docs/src/examples/gallery.md
@@ -320,7 +320,7 @@ x = linspace(0, 10, 100)
         width = "4cm",
         no_markers
     },
-    nothing,
+    {"group/empty plot"},
     {xmin=5, xmax=10, ymin=50, ymax=100},
     plot,
     {xmax=5, ymax=50},

--- a/src/axislike.jl
+++ b/src/axislike.jl
@@ -102,9 +102,7 @@ The `contents` after the global options are processed as follows:
 
 1. [`Options`](@ref) (ie from `@pgf {}`) will emit a `\\nextgroupplot` with the given options,
 
-2. `nothing` is emitted as a `\\nextgroupplot[group/empty plot]`,
-
-3. other values, eg `Plot` are emitted using [`print_tex`](@ref).
+2. other values, eg `Plot` are emitted using [`print_tex`](@ref).
 """
 @define_axislike GroupPlot "groupplot"
 
@@ -119,8 +117,6 @@ function print_tex(io::IO, groupplot::GroupPlot)
                 print_options(io, elt)
             elseif elt isa Plot
                 print_tex(io, elt)
-            elseif elt isa Void
-                print(io, raw"\nextgroupplot[group/empty plot]")
             else
                 print_tex(io, elt)
             end


### PR DESCRIPTION
Require `@pgf {"group/empty plot"}` in `GroupPlot` instead of using `nothing`. It is not that much longer, and it is probably better to be explicit. Using `nothing` was a bit surprising to me at first anyway. This also lets the user supply other options to the empty plot, see e.g.  #88.