### PR TITLE
allow splicing options into other options with `...`

### DIFF
--- a/docs/src/examples/axislike.md
+++ b/docs/src/examples/axislike.md
@@ -1,5 +1,7 @@
 # Axis-like objects
 
+## Simple group plot
+
 ```@setup pgf
 using PGFPlotsX
 savefigs = (figname, obj) -> begin
@@ -37,6 +39,7 @@ savefigs("groupplot-simple", ans) # hide
 
 ![](groupplot-simple.svg)
 
+## Multiple group plots
 
 ```@example pgf
 x = linspace(0, 2*pi, 100)
@@ -63,6 +66,8 @@ savefigs("groupplot-multiple", ans) # hide
 
 ![](groupplot-multiple.svg)
 
+
+## Polar axis
 
 ```@example pgf
 angles = [e/50*360*i for i in 1:500]

--- a/docs/src/examples/coordinates.md
+++ b/docs/src/examples/coordinates.md
@@ -12,6 +12,8 @@ end
 
 Use `Coordinates` to construct the `pgfplots` construct `coordinates`. Various constructors are available.
 
+## Basic usage
+
 For basic usage, consider `AbstractVectors` and iterables. Notice how non-finite values are skipped. You can also use `()` or `nothing` for jumps in functions.
 
 ```@example pgf
@@ -35,6 +37,9 @@ savefigs("coordinates-simple", ans) # hide
 
 ![](coordinates-simple.svg)
 
+
+## Error bars
+
 Use `xerror`, `xerrorplus`, `xerrorminus`, `yerror` etc. for error bars.
 
 ```@example pgf
@@ -54,6 +59,8 @@ savefigs("coordinates-errorbars", ans) # hide
 
 ![](coordinates-errorbars.svg)
 
+## 3D
+
 Use three vectors to construct 3D coordinates.
 
 ```@example pgf
@@ -70,6 +77,8 @@ savefigs("coordinates-3d", ans) # hide
 [\[.pdf\]](coordinates-3d.pdf), [\[generated .tex\]](coordinates-3d.tex)
 
 ![](coordinates-3d.svg)
+
+## Edge vectors
 
 A convenience constructor is available for plotting a matrix of values calculated from edge vectors.
 
@@ -89,6 +98,8 @@ savefigs("coordinates-3d-matrix", ans) # hide
 [\[.pdf\]](coordinates-3d-matrix.pdf), [\[generated .tex\]](coordinates-3d-matrix.tex)
 
 ![](coordinates-3d-matrix.svg)
+
+## Heatmap
 
 ```@example pgf
 x = linspace(-2, 2, 40)
@@ -114,6 +125,7 @@ savefigs("coordinates-3d-matrix-heatmap", ans) # hide
 
 ![](coordinates-3d-matrix-heatmap.svg)
 
+## Matrix plot
 
 ```@example pgf
 x = repeat(0:2, outer = 3)

--- a/docs/src/examples/gallery.md
+++ b/docs/src/examples/gallery.md
@@ -15,6 +15,7 @@ end
 
 ------------------------
 
+## Cost Error
 
 ```@example pgf
 @pgf Axis(
@@ -49,6 +50,8 @@ savefigs("cost-error", ans) # hide
 
 ------------------------
 
+## Simple Expression
+
 ```@example pgf
 using LaTeXStrings
 @pgf Axis(
@@ -68,6 +71,8 @@ savefigs("simple-expression", ans) # hide
 ![](simple-expression.svg)
 
 ------------------------
+
+## Mixing expression and coordinates
 
 ```@example pgf
 @pgf Axis(
@@ -102,13 +107,13 @@ savefigs("cost-gain", ans) # hide
 
 ------------------------
 
+## Log logLog
+
 ```@example pgf
-@pgf Axis(
+@pgf LogLogAxis(
     {
         xlabel = "Cost",
-        ylabel = "Gain",
-        xmode = "log",
-        ymode = "log",
+        ylabel = "Gain"
     },
     Plot(
         {
@@ -136,6 +141,8 @@ savefigs("cost-gain-log-log", ans) # hide
 ![](cost-gain-log-log.svg)
 
 ------------------------
+
+## Yaxis log
 
 ```@example pgf
 @pgf Axis(
@@ -171,6 +178,8 @@ savefigs("cost-gain-ylog", ans) # hide
 
 
 ------------------------
+
+## Dof vs error
 
 ```@example pgf
 using LaTeXStrings
@@ -216,6 +225,8 @@ savefigs("dof-error", ans) # hide
 
 ------------------------
 
+## Scatter classes
+
 ```@example pgf
 @pgf Axis(
     {
@@ -250,6 +261,8 @@ savefigs("table-label", ans) # hide
 
 ------------------------
 
+## Splines
+
 ```@example pgf
 @pgf Axis(
     {
@@ -282,6 +295,8 @@ savefigs("spline-quadratic", ans) # hide
 
 ------------------------
 
+## Mesh scatter
+
 ```@example pgf
 @pgf Plot3(
     {
@@ -300,6 +315,8 @@ savefigs("mesh-scatter", ans) # hide
 ![](mesh-scatter.svg)
 
 ------------------------
+
+## Group plot
 
 ```@example pgf
 # this is an imitation of the figure in the manual, as we generate the data
@@ -335,6 +352,8 @@ savefigs("groupplot-nested", ans) # hide
 ![](groupplot-nested.svg)
 
 ------------------------
+
+## Patch
 
 ```@example pgf
 @pgf Axis(Plot(

--- a/docs/src/examples/juliatypes.md
+++ b/docs/src/examples/juliatypes.md
@@ -14,6 +14,7 @@ end
 
 ## Colors.jl
 
+### LineColor
 Using a colorant as the line color
 
 ```@example pgf
@@ -41,6 +42,8 @@ savefigs("colors", ans) # hide
 [\[.pdf\]](colors.pdf), [\[generated .tex\]](colors.tex)
 
 ![](colors.svg)
+
+### Colormap
 
 Using a colormap
 
@@ -74,6 +77,69 @@ savefigs("colormap", td) # hide
 [\[.pdf\]](colormap.pdf), [\[generated .tex\]](colormap.tex)
 
 ![](colormap.svg)
+
+### ggplot2
+
+Something that looks a bit like ggplot2.
+
+```@example pgf
+using Colors
+using LaTeXStrings
+
+ggplot2 = @pgf {
+    tick_align = "outside",
+    tick_pos = "left",
+    xmajorgrids,
+    x_grid_style = "white",
+    ymajorgrids,
+    y_grid_style = "white",
+    axis_line_style = "white",
+    "axis_background/.style" = {
+        fill = "white!89.803921568627459!black"
+    }
+}
+
+ggplot2_plot = @pgf {
+    mark="*",
+    mark_size = 3,
+    mark_options = "solid",
+    line_width = "1.64pt",
+}
+
+x = 0:0.3:2
+y1 = sin.(2x)
+y2 = cos.(2x)
+y3 = cos.(5x)
+ys = [y1, y2, y3]
+n = length(ys)
+
+# Evenly spread out colors
+colors = [LCHuv(65, 100, h) for h in linspace(15, 360+15, n+1)][1:n]
+
+@pgf Axis(
+    {
+         ggplot2...,
+         xmin = -0.095, xmax = 1.995,
+         ymin = -1.1,   ymax =1.1,
+         title = L"Simple plot $\frac{\alpha}{2}$",
+         xlabel = "time (s)",
+         ylabel = "Voltage (mV)",
+    },
+    [
+        PlotInc(
+            {
+                ggplot2_plot...,
+                color = colors[i]
+            },
+            Coordinates(x, _y))
+        for (i, _y) in enumerate(ys)]...,
+)
+savefigs("ggplot", ans) # hide
+```
+
+[\[.pdf\]](ggplot.pdf), [\[generated .tex\]](ggplot.tex)
+
+![](ggplot.svg)
 
 ## DataFrames.jl
 
@@ -145,6 +211,8 @@ savefigs("contour", ans) # hide
 
 `StatsBase.Histogram` can be plotted using `Table`, both for 1D and 2D histograms.
 
+### 1D
+
 ```@example pgf
 using StatsBase: Histogram, fit
 @pgf Axis(
@@ -165,6 +233,8 @@ savefigs("histogram-1d", ans) # hide
 [\[.pdf\]](histogram-1d.pdf), [\[generated .tex\]](histogram-1d.tex)
 
 ![](histogram-1d.svg)
+
+### 2D
 
 ```@example pgf
 using StatsBase: Histogram, fit

--- a/docs/src/examples/juliatypes.md
+++ b/docs/src/examples/juliatypes.md
@@ -86,7 +86,7 @@ Something that looks a bit like ggplot2.
 using Colors
 using LaTeXStrings
 
-ggplot2 = @pgf {
+ggplot2_axis_theme = @pgf {
     tick_align = "outside",
     tick_pos = "left",
     xmajorgrids,
@@ -99,7 +99,7 @@ ggplot2 = @pgf {
     }
 }
 
-ggplot2_plot = @pgf {
+ggplot2_plot_theme = @pgf {
     mark="*",
     mark_size = 3,
     mark_options = "solid",
@@ -118,7 +118,7 @@ colors = [LCHuv(65, 100, h) for h in linspace(15, 360+15, n+1)][1:n]
 
 @pgf Axis(
     {
-         ggplot2...,
+         ggplot2_axis_theme...,
          xmin = -0.095, xmax = 1.995,
          ymin = -1.1,   ymax =1.1,
          title = L"Simple plot $\frac{\alpha}{2}$",
@@ -128,7 +128,7 @@ colors = [LCHuv(65, 100, h) for h in linspace(15, 360+15, n+1)][1:n]
     [
         PlotInc(
             {
-                ggplot2_plot...,
+                ggplot2_plot_theme...,
                 color = colors[i]
             },
             Coordinates(x, _y))

--- a/docs/src/examples/tables.md
+++ b/docs/src/examples/tables.md
@@ -13,6 +13,8 @@ savefigs = (figname, obj) -> begin
 end
 ```
 
+## Unnamed columns
+
 Let
 ```jl
 x = linspace(0, 2*pi, 100)
@@ -35,7 +37,9 @@ savefigs("table-unnamed-columns", ans) # hide
 
 ![](table-unnamed-columns.svg)
 
-or named columns:
+## Named columns
+
+Or named columns:
 
 ```@example pgf
 Plot(Table([:x => x, :y => y]))
@@ -46,7 +50,9 @@ savefigs("table-named-columns", ans) # hide
 
 ![](table-named-columns.svg)
 
-or rename using options:
+## Rename options
+
+The columns can be renamed using options:
 
 ```@example pgf
 @pgf Plot(
@@ -61,6 +67,8 @@ savefigs("table-dict-rename", ans) # hide
 [\[.pdf\]](table-dict-rename.pdf), [\[generated .tex\]](table-dict-rename.tex)
 
 ![](table-dict-rename.svg)
+
+## Excluding points
 
 In the example below, we use a matrix of values with edge vectors, and omit the points outside the unit circle:
 ```@example pgf
@@ -87,6 +95,8 @@ savefigs("table-jump-3d", ans) # hide
 [\[.pdf\]](table-jump-3d.pdf), [\[generated .tex\]](table-jump-3d.tex)
 
 ![](table-jump-3d.svg)
+
+## Quiver plot
 
 A quiver plot can be created as:
 

--- a/docs/src/man/options.md
+++ b/docs/src/man/options.md
@@ -156,4 +156,18 @@ julia> print_tex(a)
 \end{axis}
 ```
 
-It is then easy to apply, for example, a “theme” to an axis where the theme is a set of options already saved. Just `merge!` the theme into an `Axis`.
+An alternative to using `merge!` is using  `...` to splice an option into another one, e.g.
+
+```jldoctest
+julia> theme = @pgf {xmajorgrids, ymajorgrids};
+
+julia> a = Axis(
+           @pgf {theme..., title = "Foo"}
+       );
+
+julia> print_tex(a)
+\begin{axis}[xmajorgrids, ymajorgrids, title={Foo}]
+\end{axis}
+```
+
+It is then easy to apply, for example, a “theme” to an axis where the theme is a set of options already saved.

--- a/test/test_macros.jl
+++ b/test/test_macros.jl
@@ -18,8 +18,9 @@ od(args...) =  PGFPlotsX.Options(args...)
 @testset "pgf tests" begin
     a = 1
     b = 2
-    @test @pgf { xmax = a + b, title = "42", justkey } ==
-        od("xmax" => 3, "title" => "42", "justkey" => nothing)
+    theme = @pgf {color = "white"}
+    @test @pgf { xmax = a + b, title = "42", justkey, theme... } ==
+        od("xmax" => 3, "title" => "42", "justkey" => nothing, @pgf { color="white" } => nothing)
     f(x...) = tuple(x...)
     @test @pgf f({ look, we, are = f(1, 2, 3),
                        nesting = {


### PR DESCRIPTION
This makes using "themes" much nicer since you don't have to use `merge!`.

For example:

```
julia> theme = @pgf {linewidth = 10};

julia> axis_opts = @pgf {theme...,  title = "Foo"};

julia> PGFPlotsX.print_options(STDOUT, axis_opts)
[linewidth={10}, title={Foo}]
```

Also added an example of something that looks a bit like ggplot2:

<img width="482" alt="screen shot 2018-03-24 at 12 31 31" src="https://user-images.githubusercontent.com/1282691/37863509-56e37d2a-2f5f-11e8-9ab6-60998ca6c025.png">

and put some subheaders in the examples.
