### PR TITLE
run_again due to changing labels

### DIFF
--- a/src/build.jl
+++ b/src/build.jl
@@ -30,11 +30,16 @@ function run_latex_once(filename::String, eng::LaTeXEngine, flags)
     cmd = `$(_engine_cmd(eng)) $flags $file`
     succ = cd(() -> success(cmd), dir)
     logfile = _replace_fileext(filename, ".log")
-    auxfile = _replace_fileext(filename, ".aux")
     log = readstring(logfile)
+    succ, log, cmd
+end
+
+function rm_tmpfiles(filename::String)
+    logfile = _replace_fileext(filename, ".log")
+    auxfile = _replace_fileext(filename, ".aux")
     rm(logfile; force = true)
     rm(auxfile; force = true)
-    succ, log, cmd
+    rm(filename; force = true)
 end
 
 DEFAULT_FLAGS = Union{String}[] # no default flags currently

--- a/src/tikzdocument.jl
+++ b/src/tikzdocument.jl
@@ -148,7 +148,7 @@ function savepdf(filename::String, td::TikzDocument;
 
     tmp_tex = tmp * ".tex"
     tmp_pdf = tmp * ".pdf"
-    if run_count == 0 savetex(tmp_tex, td) end
+    savetex(tmp_tex, td)
     latex_success, log, latexcmd = run_latex_once(tmp_tex,
                                                   latex_engine, buildflags)
 

--- a/test/test_build.jl
+++ b/test/test_build.jl
@@ -107,3 +107,23 @@ end
         end
     end
 end
+
+@testset "legend to name; ref" begin
+    tmp_pdf = tempname() * ".pdf"
+    mktempdir() do dir
+        cd(dir) do
+            @pgf a = [Axis({legend_to_name = "named",
+                            title = "k = $k", legend_columns = 2,
+                            legend_entries = {"\$x^k\$", "\$(x + 1)^k\$"}},
+                            PlotInc(Expression("x^$k")),
+                            PlotInc(Expression("(x + 1)^$k")))
+                      for k in 1:3]
+            p = TikzPicture("\\matrix{", a[1], "&", a[2], "&", a[3], raw"\\\\};",
+                            raw"\node at (.5, -4.5) {\ref{named}};")
+            pgfsave(tmp_pdf, p)
+            @test is_pdf_file(tmp_pdf)
+            rm(tmp_pdf)
+        end
+    end
+end
+


### PR DESCRIPTION
The temporary aux file from the first run is used to get the references right in the second run.
Therefore tmp_tex and auxfile should be the same in the first and second run.
All temporary files are removed either before an error is thrown or before the temporary pdf is moved.