### PR TITLE
Wrap labels in Legend in braces.

### DIFF
--- a/docs/src/man/axiselements.md
+++ b/docs/src/man/axiselements.md
@@ -87,7 +87,7 @@ Example:
 
 ```jldoctest
 julia> print_tex(Legend(["Plot A", "Plot B"]))
-\legend{Plot A, Plot B}
+\legend{{Plot A}, {Plot B}}
 ```
 
 ## [Using LaTeX code directly](@id latex_code_strings)

--- a/src/axiselements.jl
+++ b/src/axiselements.jl
@@ -618,10 +618,13 @@ end
 
 Corresponds to `\\legend{ ... }` in PGFPlots. Specifies multiple legends for
 an axis, its position is irrelevant.
+
+`labels` are wrapped in `{}`s, so they can contain `,`.
 """
 Legend(labels::AbstractString...) = Legend(collect(String, labels))
 
-print_tex(io::IO, l::Legend) = println(io, "\\legend{", join(l.labels, ", "), "}")
+print_tex(io::IO, l::Legend) =
+    println(io, "\\legend{{", join(l.labels, "}, {"), "}}")
 
 ###############
 # LegendEntry #

--- a/test/test_elements.jl
+++ b/test/test_elements.jl
@@ -181,7 +181,7 @@ end
         "\\addplot[no marks]\n    table[row sep={\\\\}]\n    {\n        x  y  \\\\\n" *
         "        1  3  \\\\\n        2  4  \\\\\n    }\n    trailing\n    ;\n"
     # legend
-    @test repr_tex(Legend(["a", "b", "c"])) == "\\legend{a, b, c}\n"
+    @test repr_tex(Legend(["a", "b", "c"])) == "\\legend{{a}, {b}, {c}}\n"
     l = LegendEntry("a")
     @test repr_tex(l) == "\\addlegendentry[] {a}\n"
     # axis


### PR DESCRIPTION
This protects labels with commas, eg `Legend("N(0, 1)")`, from being split.