### PR TITLE
Do not print data file name with newlines

### DIFF
--- a/docs/src/man/axiselements.md
+++ b/docs/src/man/axiselements.md
@@ -40,11 +40,7 @@ julia> p = @pgf PlotInc({ blue }, Table("plotdata/invcum.dat"));
 
 julia> print_tex(p)
 \addplot+[blue]
-    table[]
-    {
-        plotdata/invcum.dat
-    }
-    ;
+    table[] {plotdata/invcum.dat};
 ```
 
 ### Plot3

--- a/docs/src/man/axislike.md
+++ b/docs/src/man/axislike.md
@@ -80,19 +80,11 @@ julia> print_tex(gp)
     \addplot[]
         {x^2};
     \addplot[]
-        table[]
-        {
-            data1.dat
-        }
-        ;
+        table[] {data1.dat};
     \addplot[]
         {exp(x)};
     \addplot[]
-        table[]
-        {
-            data2.dat
-        }
-        ;
+        table[] {data2.dat};
 \end{groupplot}
 ```
 
@@ -112,11 +104,7 @@ julia> print_tex(gp)
     \addplot[]
         {x^2};
     \addplot[]
-        table[]
-        {
-            data2.dat
-        }
-        ;
+        table[] {data2.dat};
 \end{groupplot}
 ```
 

--- a/src/axiselements.jl
+++ b/src/axiselements.jl
@@ -475,9 +475,15 @@ function print_tex(io::IO, table::Table)
     @unpack options, content = table
     print(io, "table")
     print_options(io, merge(container_options(content, table), options))
-    println(io, "{")
-    print_indent(io, content)
-    println(io, "}")
+    if content isa String
+        print(io, "{")
+        print(io, content)
+        print(io, "}")
+    else
+        println(io, "{")
+        print_indent(io, content)
+        println(io, "}")
+    end
 end
 
 ############

--- a/src/axiselements.jl
+++ b/src/axiselements.jl
@@ -474,7 +474,7 @@ container_options(::AbstractString, ::Table) = Options() # included from file
 function print_tex(io::IO, table::Table)
     @unpack options, content = table
     print(io, "table")
-    print_options(io, merge(container_options(content, table), options))
+    print_options(io, merge(container_options(content, table), options), newline=false)
     if content isa String
         print(io, "{")
         print(io, content)

--- a/src/axiselements.jl
+++ b/src/axiselements.jl
@@ -474,12 +474,13 @@ container_options(::AbstractString, ::Table) = Options() # included from file
 function print_tex(io::IO, table::Table)
     @unpack options, content = table
     print(io, "table")
-    print_options(io, merge(container_options(content, table), options), newline=false)
     if content isa String
+        print_options(io, merge(container_options(content, table), options), newline=false)
         print(io, "{")
         print(io, content)
         print(io, "}")
     else
+        print_options(io, merge(container_options(content, table), options), newline=true)
         println(io, "{")
         print_indent(io, content)
         println(io, "}")

--- a/test/test_elements.jl
+++ b/test/test_elements.jl
@@ -127,14 +127,14 @@ end
                                       [1 NaN;
                                        -Inf 4.0],
                                       ["xx", "yy"],
-                                      [1])) == "table[row sep={\\\\}] {\nxx yy \\\\\n1.0 nan \\\\\n\\\\\n-inf 4.0 \\\\\n}"
+                                      [1])) == "table[row sep={\\\\}]\n{\nxx yy \\\\\n1.0 nan \\\\\n\\\\\n-inf 4.0 \\\\\n}"
 end
 
 @testset "table file" begin
     path = "somefile.dat"
     @test squashed_repr_tex(Table(@pgf({x = "a", y = "b"}), path)) ==
-        "table[x={a}, y={b}]\n{$(path)}"
-    @test squashed_repr_tex(Table(path)) == "table[]\n{$(path)}"
+        "table[x={a}, y={b}] {$(path)}"
+    @test squashed_repr_tex(Table(path)) == "table[] {$(path)}"
 end
 
 @testset "plot" begin

--- a/test/test_elements.jl
+++ b/test/test_elements.jl
@@ -133,8 +133,8 @@ end
 @testset "table file" begin
     path = "somefile.dat"
     @test squashed_repr_tex(Table(@pgf({x = "a", y = "b"}), path)) ==
-        "table[x={a}, y={b}]\n{\n$(path)\n}"
-    @test squashed_repr_tex(Table(path)) == "table[]\n{\n$(path)\n}"
+        "table[x={a}, y={b}]\n{$(path)}"
+    @test squashed_repr_tex(Table(path)) == "table[]\n{$(path)}"
 end
 
 @testset "plot" begin

--- a/test/test_elements.jl
+++ b/test/test_elements.jl
@@ -127,7 +127,7 @@ end
                                       [1 NaN;
                                        -Inf 4.0],
                                       ["xx", "yy"],
-                                      [1])) == "table[row sep={\\\\}]\n{\nxx yy \\\\\n1.0 nan \\\\\n\\\\\n-inf 4.0 \\\\\n}"
+                                      [1])) == "table[row sep={\\\\}] {\nxx yy \\\\\n1.0 nan \\\\\n\\\\\n-inf 4.0 \\\\\n}"
 end
 
 @testset "table file" begin


### PR DESCRIPTION
Having all these newlines when specifying the data file name makes the plot fail.

ex:

```tex
\begin{tikzpicture}[every plot/.append style={thick}]
\begin{semilogyaxis}[xlabel={$f_1$ (GHz)}, ylabel={Infidelity}, grid={major}, legend entries={2 qubits, 3 qubits, 4 qubits, 5 qubits}, legend pos={north west}]
    \addplot
        table
		{
			Figures/StateDepShift/data-2Q.tsv
		}
	;
    \addplot
        table {Figures/StateDepShift/data-3Q.tsv};
    \addplot
        table {Figures/StateDepShift/data-4Q.tsv};
    \addplot
        table {Figures/StateDepShift/data-5Q.tsv};
\end{semilogyaxis}
\end{tikzpicture}
```

produces the following, with the first plot missing:

![image](https://user-images.githubusercontent.com/11141558/39712373-c396be56-51f0-11e8-8ada-efa3860e9286.png)

and the following warning:

```
Package pgfplots Warning: the current plot has no coordinates (or all have been
 filtered away) on input line 8.
```