### PR TITLE
Don't print empty options by default.

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,9 +1,11 @@
 julia 0.6
 ArgCheck
+AutoHashEquals
 MacroTools
 Compat
 DataStructures
 DocStringExtensions
+Lazy
 Missings
 Parameters
 Requires

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,5 @@
 julia 0.6
 ArgCheck
-AutoHashEquals
 MacroTools
 Compat
 DataStructures

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,10 +1,9 @@
 julia 0.6
 ArgCheck
-MacroTools
 Compat
 DataStructures
 DocStringExtensions
-Lazy
+MacroTools
 Missings
 Parameters
 Requires

--- a/docs/src/man/axiselements.md
+++ b/docs/src/man/axiselements.md
@@ -40,7 +40,7 @@ julia> p = @pgf PlotInc({ blue }, Table("plotdata/invcum.dat"));
 
 julia> print_tex(p)
 \addplot+[blue]
-    table[] {plotdata/invcum.dat};
+    table {plotdata/invcum.dat};
 ```
 
 ### Plot3

--- a/docs/src/man/axislike.md
+++ b/docs/src/man/axislike.md
@@ -34,7 +34,7 @@ julia> @pgf a = Axis({
 
 julia> print_tex(a)
 \begin{axis}[xlabel={x}, ylabel={y}, title={Figure}]
-    \addplot+[]
+    \addplot+
         {x^2};
 \end{axis}
 
@@ -43,9 +43,9 @@ julia> push!(a, PlotInc(Coordinates([1, 2], [3, 4])));
 
 julia> print_tex(a)
 \begin{axis}[xlabel={x}, ylabel={y}, title={Figure}]
-    \addplot+[]
+    \addplot+
         {x^2};
-    \addplot+[]
+    \addplot+
         coordinates {
             (1, 3)
             (2, 4)
@@ -77,14 +77,14 @@ julia> for (expr, data) in zip(["x^2", "exp(x)"], ["data1.dat", "data2.dat"])
 
 julia> print_tex(gp)
 \begin{groupplot}[group style={group size={2 by 1}}, height={6cm}, width={6cm}]
-    \addplot[]
+    \addplot
         {x^2};
-    \addplot[]
-        table[] {data1.dat};
-    \addplot[]
+    \addplot
+        table {data1.dat};
+    \addplot
         {exp(x)};
-    \addplot[]
-        table[] {data2.dat};
+    \addplot
+        table {data2.dat};
 \end{groupplot}
 ```
 
@@ -101,10 +101,10 @@ julia> @pgf for (expr, data) in zip(["x^2"], ["data2.dat"])
 julia> print_tex(gp)
 \begin{groupplot}[group style={group size={1 by 1}}, height={6cm}, width={6cm}]
     \nextgroupplot[title={Data data2.dat}]
-    \addplot[]
+    \addplot
         {x^2};
-    \addplot[]
-        table[] {data2.dat};
+    \addplot
+        table {data2.dat};
 \end{groupplot}
 ```
 
@@ -118,8 +118,8 @@ Example:
 julia> p = PolarAxis( PlotInc( Coordinates([0, 90, 180, 270], [1, 1, 1, 1])));
 
 julia> print_tex(p)
-\begin{polaraxis}[]
-    \addplot+[]
+\begin{polaraxis}
+    \addplot+
         coordinates {
             (0, 1)
             (90, 1)

--- a/docs/src/man/data.md
+++ b/docs/src/man/data.md
@@ -133,5 +133,5 @@ Example:
 
 ```jldoctest
 julia> print_tex(Graphics("img.png"))
-graphics[] {img.png}
+graphics {img.png}
 ```

--- a/docs/src/man/options.md
+++ b/docs/src/man/options.md
@@ -174,8 +174,8 @@ It is then easy to apply, for example, a “theme” to an axis where the theme 
 
 ## Empty options
 
-Empty options are not printed by default, but printing `[]` can be useful in some cases, eg when combined with global settings `\pgfplotsset{every axis plot/.append style={...}}` in LaTeX code. In order to force printing empty options, use something like
+Empty options are not printed by default, but printing `[]` can be useful in some cases, eg when combined with global settings `\pgfplotsset{every axis plot/.append style={...}}` in LaTeX code. In order to force printing empty options, it is recommended to use `{}` in expressions like
 
 ```julia
-Axis(Options(; print_empty = true), ...)
+@pgf Plot({}, ...)
 ```

--- a/docs/src/man/options.md
+++ b/docs/src/man/options.md
@@ -171,3 +171,11 @@ julia> print_tex(a)
 ```
 
 It is then easy to apply, for example, a “theme” to an axis where the theme is a set of options already saved.
+
+## Empty options
+
+Empty options are not printed by default, but printing `[]` can be useful in some cases, eg when combined with global settings `\pgfplotsset{every axis plot/.append style={...}}` in LaTeX code. In order to force printing empty options, use something like
+
+```julia
+Axis(Options(; print_empty = true), ...)
+```

--- a/docs/src/man/picdoc.md
+++ b/docs/src/man/picdoc.md
@@ -19,8 +19,8 @@ julia> tp = @pgf TikzPicture({ "scale" => 1.5 }, Axis(Plot(Coordinates([1, 2], [
 
 julia> print_tex(tp)
 \begin{tikzpicture}[scale={1.5}]
-\begin{axis}[]
-    \addplot[]
+\begin{axis}
+    \addplot
         coordinates {
             (1, 2)
             (2, 4)

--- a/docs/src/man/structs.md
+++ b/docs/src/man/structs.md
@@ -15,7 +15,7 @@ Instead, this manual describes a way to conveniently generate what LaTeX output 
 As an example, consider the following trivial plot:
 
 ```tex
-\begin{tikzpicture}[]
+\begin{tikzpicture}
 \begin{axis}
     \addplot+[only marks] table {
             x  y

--- a/src/PGFPlotsX.jl
+++ b/src/PGFPlotsX.jl
@@ -5,10 +5,12 @@ module PGFPlotsX
 import MacroTools: prewalk, @capture
 
 using ArgCheck
+using AutoHashEquals
 using Compat
 using Compat.Unicode            # for lowercase
 using DataStructures
 using DocStringExtensions
+using Lazy: @forward
 using Missings
 using Parameters
 using Requires

--- a/src/PGFPlotsX.jl
+++ b/src/PGFPlotsX.jl
@@ -2,14 +2,13 @@ __precompile__()
 
 module PGFPlotsX
 
-import MacroTools: prewalk, @capture
+import MacroTools: prewalk, @capture, @forward
 
 using ArgCheck
 using Compat
 using Compat.Unicode            # for lowercase
 using DataStructures
 using DocStringExtensions
-using Lazy: @forward
 using Missings
 using Parameters
 using Requires

--- a/src/PGFPlotsX.jl
+++ b/src/PGFPlotsX.jl
@@ -5,7 +5,6 @@ module PGFPlotsX
 import MacroTools: prewalk, @capture
 
 using ArgCheck
-using AutoHashEquals
 using Compat
 using Compat.Unicode            # for lowercase
 using DataStructures

--- a/src/options.jl
+++ b/src/options.jl
@@ -41,7 +41,7 @@ function procmap(d)
     elseif !@capture(d, {xs__})
         return d
     else
-        return :($(Options)($(map(prockey, xs)...)))
+        return :($(Options)($(map(prockey, xs)...); print_empty = true))
     end
 end
 
@@ -77,6 +77,8 @@ theme = @pgf {xmajorgrids, x_grid_style = "white"}
 
 axis_opt = @pgf {theme..., title = "My figure"}
 ```
+
+Use `{}` for empty options that print as `[]` in LaTeX.
 """
 macro pgf(ex)
     esc(prewalk(procmap, ex))

--- a/src/options.jl
+++ b/src/options.jl
@@ -1,4 +1,4 @@
-@auto_hash_equals struct Options
+struct Options
     dict::OrderedDict{Any, Any}
     print_empty::Bool
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,7 +18,7 @@ PGFPlotsX.latexengine!(PGFPlotsX.PDFLATEX)
 
 include("utilities.jl")
 
-include("test_macros.jl")
+include("test_options.jl")
 
 include("test_elements.jl")
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
 using PGFPlotsX
+using PGFPlotsX: Options
 using Base.Test
 using Colors
 using Compat

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,6 +16,8 @@ end
 @show PGFPlotsX.latexengine
 PGFPlotsX.latexengine!(PGFPlotsX.PDFLATEX)
 
+include("utilities.jl")
+
 include("test_macros.jl")
 
 include("test_elements.jl")

--- a/test/test_build.jl
+++ b/test/test_build.jl
@@ -126,4 +126,3 @@ end
         end
     end
 end
-

--- a/test/test_elements.jl
+++ b/test/test_elements.jl
@@ -104,12 +104,12 @@ end
 @testset "plot" begin
     # sanity checks for constructors and printing, 2D
     data2 = Table(x = 1:2, y = 3:4)
-    p2 = Plot(false, false, PGFPlotsX.Options(), data2, [raw"\closedcycle"])
+    p2 = Plot(false, false, Options(), data2, [raw"\closedcycle"])
     @test squashed_repr_tex(p2) ==
         "\\addplot\ntable[row sep={\\\\}]\n{\nx y \\\\\n1 3 \\\\\n2 4 \\\\\n}\n\\closedcycle\n;"
-    @test Plot(@pgf({}), data2, raw"\closedcycle") ≅ p2
-    @test PlotInc(@pgf({}), data2, raw"\closedcycle") ≅
-        Plot(false, true, PGFPlotsX.Options(), data2, [raw"\closedcycle"])
+    @test Plot(data2, raw"\closedcycle") ≅ p2
+    @test PlotInc(data2, raw"\closedcycle") ≅
+        Plot(false, true, Options(), data2, [raw"\closedcycle"])
     @test PlotInc(data2, raw"\closedcycle") ≅
         Plot(false, true, PGFPlotsX.Options(), data2, [raw"\closedcycle"])
     @test Plot(data2, raw"\closedcycle") ≅ p2

--- a/test/test_elements.jl
+++ b/test/test_elements.jl
@@ -134,7 +134,7 @@ end
     path = "somefile.dat"
     @test squashed_repr_tex(Table(@pgf({x = "a", y = "b"}), path)) ==
         "table[x={a}, y={b}] {$(path)}"
-    @test squashed_repr_tex(Table(path)) == "table[] {$(path)}"
+    @test squashed_repr_tex(Table(path)) == "table {$(path)}"
 end
 
 @testset "plot" begin
@@ -142,7 +142,7 @@ end
     data2 = Table(x = 1:2, y = 3:4)
     p2 = Plot(false, false, PGFPlotsX.Options(), data2, [raw"\closedcycle"])
     @test squashed_repr_tex(p2) ==
-        "\\addplot[]\ntable[row sep={\\\\}]\n{\nx y \\\\\n1 3 \\\\\n2 4 \\\\\n}\n\\closedcycle\n;"
+        "\\addplot\ntable[row sep={\\\\}]\n{\nx y \\\\\n1 3 \\\\\n2 4 \\\\\n}\n\\closedcycle\n;"
     @test Plot(@pgf({}), data2, raw"\closedcycle") ≅ p2
     @test PlotInc(@pgf({}), data2, raw"\closedcycle") ≅
         Plot(false, true, PGFPlotsX.Options(), data2, [raw"\closedcycle"])
@@ -151,7 +151,7 @@ end
     @test Plot(data2, raw"\closedcycle") ≅ p2
     # printing incremental w/ options, 2D and 3D
     @test squashed_repr_tex(PlotInc(data2)) ==
-        "\\addplot+[]\ntable[row sep={\\\\}]\n{\nx y \\\\\n1 3 \\\\\n2 4 \\\\\n}\n;"
+        "\\addplot+\ntable[row sep={\\\\}]\n{\nx y \\\\\n1 3 \\\\\n2 4 \\\\\n}\n;"
     @test squashed_repr_tex(@pgf Plot3Inc({xtick = 1:3},
                                           Table(x = 1:2, y = 3:4, z = 5:6))) ==
         "\\addplot3+[xtick={1,2,3}]\ntable[row sep={\\\\}]\n{\nx y z \\\\\n1 3 5 \\\\\n2 4 6 \\\\\n}\n;"
@@ -183,10 +183,15 @@ end
     # legend
     @test repr_tex(Legend(["a", "b", "c"])) == "\\legend{{a}, {b}, {c}}\n"
     l = LegendEntry("a")
-    @test repr_tex(l) == "\\addlegendentry[] {a}\n"
+    @test repr_tex(l) == "\\addlegendentry {a}\n"
     # axis
     @test repr_tex(@pgf Axis({ optaxis }, Plot({ optplot }, c), l)) ==
         "\\begin{axis}[optaxis]\n    \\addplot[optplot]\n" *
         "        coordinates {\n            (1, 2)\n            (3, 4)\n        }\n" *
-        "        ;\n    \\addlegendentry[] {a}\n\\end{axis}\n"
+        "        ;\n    \\addlegendentry {a}\n\\end{axis}\n"
+end
+
+@testset "explicit empty options" begin
+    @test repr_tex(Axis(Options(; print_empty = true))) ==
+        "\\begin{axis}[]\n\\end{axis}\n"
 end

--- a/test/test_elements.jl
+++ b/test/test_elements.jl
@@ -1,39 +1,3 @@
-"Invoke print_tex with the given arguments, collect the results in a string."
-function repr_tex(args...)
-    io = IOBuffer()
-    print_tex(io, args...)
-    String(take!(io))
-end
-
-"""
-Trim lines, merge whitespace to a single space, merge multiple empty lines into
-one, merge beginning and ending newlines.
-
-Useful for unit testing printed representations.
-"""
-function squash_whitespace(str::AbstractString)
-    lines = split(str, '\n')
-    squashed_lines = map(line -> replace(strip(line), r" +", " "), lines)
-    strip(replace(join(squashed_lines, "\n"), r"\n{2,}", "\n\n"), '\n')
-end
-
-@test squash_whitespace("\n\n  a  line  \nsome   other line\n\n\ndone\n") ==
-    "a line\nsome other line\n\ndone"
-
-"Squashed result of `print_tex` with given arguments."
-squashed_repr_tex(args...) = squash_whitespace(repr_tex(args...))
-
-"A simple comparison of fields for unit tests."
-≅(x, y) = x == y
-
-function ≅(x::T, y::T) where T <: Union{PGFPlotsX.Coordinate, Coordinates,
-                                        Table, TableData, Plot}
-    for f in fieldnames(T)
-        getfield(x, f) ≅ getfield(y, f) || return false
-    end
-    true
-end
-
 @testset "printing Julia types to TeX" begin
     @test squashed_repr_tex("something") == "something"
     @test squashed_repr_tex(4) == "4"
@@ -88,8 +52,8 @@ end
 
 @testset "tables" begin
     # compare results to these using ≅, defined above
-    table_named_noopt = Table(PGFPlotsX.Options(), hcat(1:10, 11:20), ["a", "b"], Int[])
-    table_unnamed_noopt = Table(PGFPlotsX.Options(), hcat(1:10, 11:20), nothing, Int[])
+    table_named_noopt = Table(hcat(1:10, 11:20), ["a", "b"], Int[])
+    table_unnamed_noopt = Table(hcat(1:10, 11:20), nothing, Int[])
     opt = @pgf { meaningless = "option" }
     table_named_opt = Table(opt, hcat(1:10, 11:20), ["a", "b"], Int[])
 

--- a/test/test_macros.jl
+++ b/test/test_macros.jl
@@ -10,23 +10,19 @@ end
     @test TestModule.testpgf() ≠ nothing
 end
 
-
-# test the @pgf macro
-
-od(args...) =  PGFPlotsX.Options(args...)
-
 @testset "pgf tests" begin
     a = 1
     b = 2
     theme = @pgf {color = "white"}
     @test @pgf { xmax = a + b, title = "42", justkey, theme... } ==
-        od("xmax" => 3, "title" => "42", "justkey" => nothing, @pgf { color="white" } => nothing)
+        Options("xmax" => 3, "title" => "42", "justkey" => nothing,
+                @pgf { color="white" } => nothing)
     f(x...) = tuple(x...)
     @test @pgf f({ look, we, are = f(1, 2, 3),
                        nesting = {
                            stuff = 9
-                       }}) == (od("look" => nothing,
-                                  "we" => nothing,
-                                  "are" => (1, 2, 3),
-                                  "nesting" => od("stuff" => 9)), )
+                       }}) == (Options("look" => nothing,
+                                       "we" => nothing,
+                                       "are" => (1, 2, 3),
+                                       "nesting" => Options("stuff" => 9)), )
 end

--- a/test/test_macros.jl
+++ b/test/test_macros.jl
@@ -14,15 +14,14 @@ end
     a = 1
     b = 2
     theme = @pgf {color = "white"}
-    @test @pgf { xmax = a + b, title = "42", justkey, theme... } ==
-        Options("xmax" => 3, "title" => "42", "justkey" => nothing,
-                @pgf { color="white" } => nothing)
+    @test repr_tex(@pgf { xmax = a + b, title = "42", justkey, theme... }) ==
+        repr_tex(Options("xmax" => 3, "title" => "42", "justkey" => nothing,
+                         @pgf { color="white" } => nothing))
     f(x...) = tuple(x...)
-    @test @pgf f({ look, we, are = f(1, 2, 3),
-                       nesting = {
-                           stuff = 9
-                       }}) == (Options("look" => nothing,
-                                       "we" => nothing,
-                                       "are" => (1, 2, 3),
-                                       "nesting" => Options("stuff" => 9)), )
+    y = @pgf f({ look, we, are = f(1, 2, 3), nesting = { stuff = 9 }})
+    @test length(y) == 1
+    @test repr_tex(y[1]) == repr_tex(Options("look" => nothing,
+                                             "we" => nothing,
+                                             "are" => (1, 2, 3),
+                                             "nesting" => Options("stuff" => 9)))
 end

--- a/test/test_options.jl
+++ b/test/test_options.jl
@@ -25,3 +25,8 @@ end
                                              "are" => (1, 2, 3),
                                              "nesting" => Options("stuff" => 9)))
 end
+
+@testset "pgf empty" begin
+    @test squashed_repr_tex(@pgf Plot({}, Table([], []))) ==
+        "\\addplot[]\ntable[row sep={\\\\}]\n{\n\\\\\n}\n;" # note []
+end

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -1,0 +1,43 @@
+# utilities for testing
+
+"Invoke print_tex with the given arguments, collect the results in a string."
+function repr_tex(args...)
+    io = IOBuffer()
+    print_tex(io, args...)
+    String(take!(io))
+end
+
+function repr_tex(options::Options)
+    io = IOBuffer()
+    PGFPlotsX.print_options(io, options; newline = false)
+    String(take!(io))
+end
+
+"""
+Trim lines, merge whitespace to a single space, merge multiple empty lines into
+one, merge beginning and ending newlines.
+
+Useful for unit testing printed representations.
+"""
+function squash_whitespace(str::AbstractString)
+    lines = split(str, '\n')
+    squashed_lines = map(line -> replace(strip(line), r" +", " "), lines)
+    strip(replace(join(squashed_lines, "\n"), r"\n{2,}", "\n\n"), '\n')
+end
+
+@test squash_whitespace("\n\n  a  line  \nsome   other line\n\n\ndone\n") ==
+    "a line\nsome other line\n\ndone"
+
+"Squashed result of `print_tex` with given arguments."
+squashed_repr_tex(args...) = squash_whitespace(repr_tex(args...))
+
+"A simple comparison of fields for unit tests."
+≅(x, y) = x == y
+
+function ≅(x::T, y::T) where T <: Union{PGFPlotsX.Coordinate, Coordinates,
+                                        Table, TableData, Plot, Options}
+    for f in fieldnames(T)
+        getfield(x, f) ≅ getfield(y, f) || return false
+    end
+    true
+end


### PR DESCRIPTION
Follow-up to #99.

1. Define a simple wrapper type for `Options`.

2. Use the `Lazy.@forward` macro for DRY when possible.

3. Simplify `@pgf` tests a bit, no need for a constructor function.

4. Modify doctests and manual accordingly.