### PR TITLE
More deprecation fixes after looking at the docs output.

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -6,4 +6,5 @@ MacroTools
 Missings
 Parameters
 Requires 0.5.2
+StatsBase 0.24
 Crayons

--- a/docs/src/examples/axislike.md
+++ b/docs/src/examples/axislike.md
@@ -70,7 +70,7 @@ savefigs("groupplot-multiple", ans) # hide
 ## Polar axis
 
 ```@example pgf
-angles = [e/50*360*i for i in 1:500]
+angles = [ℯ/50*360*i for i in 1:500]
 radius = [1/(sqrt(i)) for i in range(1; stop = 10, length = 500)]
 PolarAxis(PlotInc(Coordinates(angles, radius)))
 savefigs("polar", ans) # hide

--- a/src/PGFPlotsX.jl
+++ b/src/PGFPlotsX.jl
@@ -8,6 +8,7 @@ using ArgCheck: @argcheck
 using DataStructures: OrderedDict
 using DocStringExtensions: SIGNATURES, TYPEDEF
 using Parameters: @unpack
+using StatsBase: midpoints
 using Requires: @require
 using Unicode: lowercase
 

--- a/src/requires.jl
+++ b/src/requires.jl
@@ -63,9 +63,6 @@ function __init__()
     end
 
     @require StatsBase="2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91" begin
-        # workaround for https://github.com/JuliaStats/StatsBase.jl/issues/344
-        const _midpoints = x -> middle.(x[2:end], x[1:(end-1)])
-
         function PGFPlotsX.TableData(h::StatsBase.Histogram{T, 1};
                                      kwargs...) where T
             PGFPlotsX.TableData(hcat(h.edges[1], vcat(h.weights, 0)),
@@ -74,14 +71,14 @@ function __init__()
 
         function PGFPlotsX.TableData(histogram::StatsBase.Histogram{T, 2};
                                      kwargs...) where T
-            PGFPlotsX.TableData(_midpoints(histogram.edges[1]),
-                                _midpoints(histogram.edges[2]),
+            PGFPlotsX.TableData(midpoints(histogram.edges[1]),
+                                midpoints(histogram.edges[2]),
                                 histogram.weights; kwargs...)
         end
 
         function PGFPlotsX.Coordinates(histogram::StatsBase.Histogram{T, 2}) where T
-            PGFPlotsX.Coordinates(_midpoints(histogram.edges[1]),
-                                  _midpoints(histogram.edges[2]),
+            PGFPlotsX.Coordinates(midpoints(histogram.edges[1]),
+                                  midpoints(histogram.edges[2]),
                                   histogram.weights)
         end
     end


### PR DESCRIPTION
1. bring back StatsBase.midpoints now that it is part of the interface
again, remove workaround.

2. Use ℯ.