### PR TITLE
Use DefaultApplication.open to open plots.

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,7 @@
 julia 0.7-beta
 ArgCheck
 DataStructures
+DefaultApplication
 DocStringExtensions
 MacroTools
 Missings

--- a/src/PGFPlotsX.jl
+++ b/src/PGFPlotsX.jl
@@ -6,6 +6,7 @@ import MacroTools: prewalk, @capture, @forward
 
 using ArgCheck: @argcheck
 using DataStructures: OrderedDict
+import DefaultApplication
 using DocStringExtensions: SIGNATURES, TYPEDEF
 using Parameters: @unpack
 using StatsBase: midpoints

--- a/src/tikzdocument.jl
+++ b/src/tikzdocument.jl
@@ -355,17 +355,7 @@ function Base.show(io::IO, ::MIME"text/plain", p::_SHOWABLE)
     if isinteractive() && _DISPLAY_PDF && !_is_ijulia() && !_is_juno() && isdefined(Base, :active_repl)
         filename = tempname() .* ".pdf"
         save(filename, p)
-        try
-            if Sys.isapple()
-                run(`open $filename`)
-            elseif Sys.islinux() || Sys.isbsd()
-                run(`xdg-open $filename`)
-            elseif Sys.iswindows()
-                run(`start $filename`)
-            end
-        catch e
-            error("Failed to show the generated pdf, run `PGFPlotsX.enable_interactive(false)` to stop trying to show pdfs.\n", "Error: ", sprint(Base.showerror, e))
-        end
+        DefaultApplication.open(filename)
     else
         print(io, p)
     end

--- a/src/tikzdocument.jl
+++ b/src/tikzdocument.jl
@@ -355,7 +355,11 @@ function Base.show(io::IO, ::MIME"text/plain", p::_SHOWABLE)
     if isinteractive() && _DISPLAY_PDF && !_is_ijulia() && !_is_juno() && isdefined(Base, :active_repl)
         filename = tempname() .* ".pdf"
         save(filename, p)
-        DefaultApplication.open(filename)
+        try
+            DefaultApplication.open(filename)
+        catch e
+            error("Failed to show the generated pdf, run `PGFPlotsX.enable_interactive(false)` to stop trying to show pdfs.\n", "Error: ", sprint(Base.showerror, e))
+        end
     else
         print(io, p)
     end


### PR DESCRIPTION
Alternative solution to the plot opening issue on Windows (#102). Uses [DefaultApplication](https://github.com/tpapp/DefaultApplication.jl), which is now registered.