### PR TITLE
Allow symbolic coordinates.

### DIFF
--- a/docs/src/examples/coordinates.md
+++ b/docs/src/examples/coordinates.md
@@ -59,6 +59,37 @@ savefigs("coordinates-errorbars", ans) # hide
 
 ![](coordinates-errorbars.svg)
 
+## [Symbolic coordinates](@id symbolic_coordinates_example)
+
+```@example pgf
+@pgf Axis(
+    {
+        ybar,
+        enlargelimits = 0.15,
+        legend_style =
+        {
+            at = Coordinate(0.5, -0.15),
+            anchor = "north",
+            legend_columns = -1
+        },
+        ylabel = raw"\#participants",
+        symbolic_x_coords=["tool8", "tool9", "tool10"],
+        xtick = "data",
+        nodes_near_coords,
+        nodes_near_coords_align={vertical},
+    },
+    Plot(Coordinates([("tool8", 7), ("tool9", 9), ("tool10", 4)])),
+    Plot(Coordinates([("tool8", 4), ("tool9", 4), ("tool10", 4)])),
+    Plot(Coordinates([("tool8", 1), ("tool9", 1), ("tool10", 1)])),
+    Legend(["used", "understood", "not understood"])
+)
+savefigs("coordinates-symbolic", ans) # hide
+```
+
+[\[.pdf\]](coordinates-symbolic.pdf), [\[generated .tex\]](coordinates-symbolic.tex)
+
+![](coordinates-symbolic.svg)
+
 ## 3D
 
 Use three vectors to construct 3D coordinates.

--- a/docs/src/man/axiselements.md
+++ b/docs/src/man/axiselements.md
@@ -63,9 +63,9 @@ julia> p = @pgf Plot3({ very_thick }, Coordinates(x, y, z));
 julia> print_tex(p)
 \addplot3[very thick]
     coordinates {
-        (1, 2, 3)
-        (2, 4, 9)
-        (3, 8, 27)
+        (1,2,3)
+        (2,4,9)
+        (3,8,27)
     }
     ;
 ```
@@ -83,7 +83,7 @@ Example:
 
 ```jldoctest
 julia> print_tex(Legend(["Plot A", "Plot B"]))
-\legend{{Plot A}, {Plot B}}
+\legend{{Plot A},{Plot B}}
 ```
 
 ## [Using LaTeX code directly](@id latex_code_strings)

--- a/docs/src/man/axislike.md
+++ b/docs/src/man/axislike.md
@@ -47,8 +47,8 @@ julia> print_tex(a)
         {x^2};
     \addplot+
         coordinates {
-            (1, 3)
-            (2, 4)
+            (1,3)
+            (2,4)
         }
         ;
 \end{axis}
@@ -121,10 +121,10 @@ julia> print_tex(p)
 \begin{polaraxis}
     \addplot+
         coordinates {
-            (0, 1)
-            (90, 1)
-            (180, 1)
-            (270, 1)
+            (0,1)
+            (90,1)
+            (180,1)
+            (270,1)
         }
         ;
 \end{polaraxis}

--- a/docs/src/man/data.md
+++ b/docs/src/man/data.md
@@ -52,13 +52,17 @@ If you load the DataFrames package, you can also create tables from data frames,
 
     By default, PGFPlots expects rows to be separated in a table with a newline. This can be “fragile” in LaTeX, in the sense that linebreaks may be merged with other whitespace within certain constructs, eg macros. In order to prevent this, this package uses the option `rowsep=\\` by default. This is taken care of automatically, except for inline tables where you have to specify it manually. See the `patch` plot in the [gallery](@ref manual_gallery).
 
-## [Coordinates](@id coordinates_header)
+## [Using coordinates](@id coordinates_header)
 
-Coordinates are a list of points `(x,y)` or `(x,y,z)`. They can be created as:
+Coordinates are a list of points `(x,y)` or `(x,y,z)`. PGFPlotsX wraps these in the [`Coordinate`](@ref) type, but for multiple coordinates, it is recommended that you use the `Coordinates` constructor, which has convenience features like converting non-finite numbers to skipped points (represented by `nothing`).
+
+Strings are also accepted in place of numbers, and can be used for *symbolic* coordinates (eg for categorical data). See [this example](@ref symbolic_coordinates_example).
+
+### `Coordinates`
 
 * `Coordinates(x, y, [z])` where `x` and `y` (and optionally `z`) are lists.
 
-* `Coordinates(points)` where `points` is a list of tuples, e.g. `x = [(1.0, 2.0), (2.0, 4.0)]`.
+* `Coordinates(points)` where `points` is a list of tuples, [`Coordinate`](@ref)s, or `nothing`, e.g. `x = [(1.0, 2.0), (2.0, 4.0)]`.
 
 Errors can be added to `Coordinates` with keywords.
 
@@ -106,6 +110,26 @@ coordinates {
     (2, 4) +- (0.3, 0.1)
     (3, 8) +- (0.5, 0.5)
 }
+```
+
+### Individual coordinates
+
+Use this constructor when you need just a single `Coordinate`, eg as in
+
+```julia
+@pgf Axis(
+    {
+        legend_style =
+        {
+            at = PGFPlotsX.Coordinate(0.5, -0.15),
+            anchor = "north",
+            legend_columns = -1
+        },
+    }, ...)
+```
+
+```@docs
+Coordinate
 ```
 
 ## Expression

--- a/docs/src/man/data.md
+++ b/docs/src/man/data.md
@@ -77,38 +77,38 @@ julia> x = [1, 2, 3]; y = [2, 4, 8]; z = [-1, -2, -3];
 
 julia> print_tex(Coordinates(x, y))
 coordinates {
-    (1, 2)
-    (2, 4)
-    (3, 8)
+    (1,2)
+    (2,4)
+    (3,8)
 }
 
 julia> print_tex(Coordinates(x, y, z))
 coordinates {
-    (1, 2, -1)
-    (2, 4, -2)
-    (3, 8, -3)
+    (1,2,-1)
+    (2,4,-2)
+    (3,8,-3)
 }
 
 julia> print_tex(Coordinates(x, x.^3))
 coordinates {
-    (1, 1)
-    (2, 8)
-    (3, 27)
+    (1,1)
+    (2,8)
+    (3,27)
 }
 
 julia> print_tex(Coordinates([(1.0, 2.0), (2.0, 4.0)]))
 coordinates {
-    (1.0, 2.0)
-    (2.0, 4.0)
+    (1.0,2.0)
+    (2.0,4.0)
 }
 
 julia> c = Coordinates(x, y, xerror = [0.2, 0.3, 0.5], yerror = [0.2, 0.1, 0.5]);
 
 julia> print_tex(c)
 coordinates {
-    (1, 2) +- (0.2, 0.2)
-    (2, 4) +- (0.3, 0.1)
-    (3, 8) +- (0.5, 0.5)
+    (1,2) +- (0.2,0.2)
+    (2,4) +- (0.3,0.1)
+    (3,8) +- (0.5,0.5)
 }
 ```
 

--- a/docs/src/man/options.md
+++ b/docs/src/man/options.md
@@ -26,9 +26,9 @@ julia> p = @pgf PlotInc({ "very thick", "mark" => "halfcircle" }, c);
 julia> print_tex(p); # print_tex can be used to preview the generated .tex
 \addplot+[very thick, mark={halfcircle}]
     coordinates {
-        (1, 2)
-        (2, 4)
-        (3, 8)
+        (1,2)
+        (2,4)
+        (3,8)
     }
     ;
 ```
@@ -61,9 +61,9 @@ julia> print_tex(a)
 \begin{axis}[axis background/.style={shade, top color={gray}, bottom color={white}}, ymode={log}]
     \addplot+[smooth]
         coordinates {
-            (1, 2)
-            (2, 4)
-            (3, 8)
+            (1,2)
+            (2,4)
+            (3,8)
         }
         ;
 \end{axis}
@@ -135,9 +135,9 @@ julia> delete!(p, "fill");
 julia> print_tex(p)
 \addplot+[axis background/.style={shade, top color={gray}, bottom color={white}}, very thick]
     coordinates {
-        (1, 2)
-        (2, 4)
-        (3, 8)
+        (1,2)
+        (2,4)
+        (3,8)
     }
     ;
 ```

--- a/docs/src/man/picdoc.md
+++ b/docs/src/man/picdoc.md
@@ -22,8 +22,8 @@ julia> print_tex(tp)
 \begin{axis}
     \addplot
         coordinates {
-            (1, 2)
-            (2, 4)
+            (1,2)
+            (2,4)
         }
         ;
 \end{axis}

--- a/src/PGFPlotsX.jl
+++ b/src/PGFPlotsX.jl
@@ -14,7 +14,7 @@ using Unicode: lowercase
 
 export TikzDocument, TikzPicture
 export Axis, SemiLogXAxis, SemiLogYAxis, LogLogAxis, PolarAxis, GroupPlot
-export Plot, PlotInc, Plot3, Plot3Inc, Expression, EmptyLine, Coordinates,
+export Plot, PlotInc, Plot3, Plot3Inc, Expression, Coordinate, Coordinates,
     TableData, Table, Graphics, Legend, LegendEntry
 export @pgf, pgfsave, print_tex, latexengine, latexengine!, push_preamble!
 

--- a/src/axiselements.jl
+++ b/src/axiselements.jl
@@ -33,32 +33,19 @@ end
 # Coordinate #
 ##############
 
-"""
-    EmptyLine()
-
-Placeholder for an empty line.
-
-In 2D plots, PGFPlots treats empty lines as *jumps* by default.
-
-In 3D plots (eg `surf` and similar), it is used as a scanline separator to
-establish the dimensions of the matrix.
-"""
-struct EmptyLine end
-
-print_tex(io::IO, ::EmptyLine) = println(io)
+const CoordinateType = Union{Real, AbstractString}
 
 struct Coordinate{N}
-    data::NTuple{N, Real}
+    data::NTuple{N, CoordinateType}
     error::Union{Nothing, NTuple{N, Real}}
     errorplus::Union{Nothing, NTuple{N, Real}}
     errorminus::Union{Nothing, NTuple{N, Real}}
     meta::Any
-    function Coordinate(data::NTuple{N, Real},
+    function Coordinate(data::NTuple{N, CoordinateType},
                         error::Union{Nothing, NTuple{N, Real}},
                         errorplus::Union{Nothing, NTuple{N, Real}},
                         errorminus::Union{Nothing, NTuple{N, Real}}, meta) where N
         @argcheck 2 ≤ N ≤ 3 "A Coordinate has to be two- or three dimensional."
-        @argcheck all(isfinite, data) "Non-finite coordinate values."
         @argcheck(!(error ≠ nothing &&
                     (errorplus ≠ nothing || errorminus ≠ nothing)),
                   "You can specify *either* `error`, or `errorplus`/`errorminus`.")
@@ -91,7 +78,23 @@ for constructing coordinates from arrays.
 Coordinate(data; error = nothing, errorplus = nothing, errorminus = nothing,
            meta = nothing) = Coordinate(data, error, errorplus, errorminus, meta)
 
-function print_tex(io::IO, data::NTuple{N, Real}) where N
+"""
+    $SIGNATURES
+
+Convenience constructor for 2-dimensional coordinates.
+"""
+Coordinate(x::CoordinateType, y::CoordinateType; args...) =
+    Coordinate((x, y); args...)
+
+"""
+    $SIGNATURES
+
+Convenience constructor for 3-dimensional coordinates.
+"""
+Coordinate(x::CoordinateType, y::CoordinateType, z; args...) =
+    Coordinate((x, y, z); args...)
+
+function print_tex(io::IO, data::NTuple{N, CoordinateType}, ::Coordinate) where N
     print(io, "(")
     for (i, x) in enumerate(data)
         i == 1 || print(io, ", ")
@@ -102,11 +105,11 @@ end
 
 function print_tex(io::IO, coordinate::Coordinate)
     @unpack data, error, errorplus, errorminus, meta = coordinate
-    print_tex(io, data)
+    print_tex(io, data, coordinate)
     function _print_error(prefix, error)
         if error ≠ nothing
             print(io, " $(prefix) ")
-            print_tex(io, error)
+            print_tex(io, error, coordinate)
         end
     end
     _print_error("+-", error)
@@ -121,8 +124,11 @@ function print_tex(io::IO, coordinate::Coordinate)
 end
 
 struct Coordinates{N}
-    data::AbstractVector{Union{EmptyLine, Coordinate{N}}}
+    data::AbstractVector{Union{Nothing, Coordinate{N}}}
 end
+
+coordinate_or_nothing(data, args...) =
+    all(x -> x isa AbstractString || isfinite(x), data) ? Coordinate(data, args...) : nothing
 
 """
     $SIGNATURES
@@ -131,11 +137,11 @@ Convert the argument, which can be any iterable object, to coordinates.
 
 Specifically,
 
-- `Coordinate` and `EmptyLine` are passed through *as is*,
+- `Coordinate` and `Nothing` are passed through *as is*,
 
-- 2- or 3-element tuples of finite real numbers are interpreted as coordinates,
+- 2- or 3-element tuples of finite real numbers or strings are interpreted as coordinates,
 
-- `nothing`, `()`, and coordinates with non-finite numbers become empty lines.
+- `()`, and tuples with non-finite numbers become `nothing` (representing empty lines).
 
 The resulting coordinates are checked for dimension consistency.
 
@@ -145,34 +151,34 @@ The following are equivalent:
 ```julia
 Coordinates((x, 1/x) for x in -5:5)
 Coordinates(x == 0 ? () : (x, 1/x) for x in -5:5)
-Coordinates(x == 0 ? EmptyLine() : Coordinate((x, 1/x)) for x in -5:5)
+Coordinates(x == 0 ? nothing : Coordinate((x, 1/x)) for x in -5:5)
+```
+
+Use `enumerate` to add 1, 2, … for the `x`-axis to an existing set of `y` coordinates:
+```julia
+Coordinates(enumerate([1, 4, 9]))
 ```
 """
 function Coordinates(itr)
     common_N = 0
     check_N(N) = common_N == 0 ? common_N = N :
         @argcheck N == common_N "Incompatible dimensions."
-    ensure_c(::Union{EmptyLine, Nothing, Tuple{}}) = EmptyLine()
+    ensure_c(::Union{Nothing, Tuple{}}) = nothing
     ensure_c(c::Coordinate{N}) where N = (check_N(N); c)
-    function ensure_c(data::NTuple{N, Real}) where N
-        check_N(N)
-        if all(isfinite, data)
-            Coordinate(data)
-        else
-            EmptyLine()
-        end
-    end
     ensure_c(x) = throw(ArgumentError("Can't interpret $x as a coordinate."))
+    function ensure_c(data::NTuple{N, CoordinateType}) where N
+        check_N(N)
+        coordinate_or_nothing(data)
+    end
     data = [ensure_c(data) for data in itr]
+    @argcheck common_N ≠ 0 || "Could not determine dimension from coordinates"
     Coordinates{common_N}(data)
 end
 
 expand_errors(_::Nothing...) = nothing
 
+# mixed reals and `nothing`: replace the latter by 0s
 expand_errors(data::Union{Real, Nothing}...) = map(x -> x isa Nothing ? 0 : x, data)
-
-coordinate_or_emptyline(data, args...) =
-    all(isfinite, data) ? Coordinate(data, args...) : EmptyLine()
 
 """
     $SIGNATURES
@@ -184,11 +190,14 @@ function Coordinates(x::AbstractVector, y::AbstractVector;
                      xerrorplus = nothing, yerrorplus = nothing,
                      xerrorminus = nothing, yerrorminus = nothing,
                      meta = nothing)
-    Coordinates{2}(@. coordinate_or_emptyline(tuple(x, y),
-                                              expand_errors(xerror, yerror),
-                                              expand_errors(xerrorplus, yerrorplus),
-                                              expand_errors(xerrorminus, yerrorminus),
-                                              meta))
+    Coordinates{2}(@. coordinate_or_nothing(tuple(x, y),
+                                            expand_errors(xerror,
+                                                          yerror),
+                                            expand_errors(xerrorplus,
+                                                          yerrorplus),
+                                            expand_errors(xerrorminus,
+                                                          yerrorminus),
+                                            meta))
 end
 
 """
@@ -198,34 +207,34 @@ Three dimensional coordinates from two vectors, with error bars.
 """
 function Coordinates(x::AbstractVector, y::AbstractVector, z::AbstractVector;
                      xerror = nothing, yerror = nothing, zerror = nothing,
-                     xerrorplus = nothing, yerrorplus = nothing, zerrorplus = nothing,
-                     xerrorminus = nothing, yerrorminus = nothing, zerrorminus = nothing,
+                     xerrorplus = nothing, yerrorplus = nothing,
+                     zerrorplus = nothing, xerrorminus = nothing,
+                     yerrorminus = nothing, zerrorminus = nothing,
                      meta = nothing)
-    Coordinates{3}(@. coordinate_or_emptyline(tuple(x, y, z),
-                                              expand_errors(xerror,
-                                                            yerror,
-                                                            zerror),
-                                              expand_errors(xerrorplus,
-                                                            yerrorplus,
-                                                            zerrorplus),
-                                              expand_errors(xerrorminus,
-                                                            yerrorminus,
-                                                            zerrorminus),
-                                              meta))
+    Coordinates{3}(@. coordinate_or_nothing(tuple(x, y, z),
+                                            expand_errors(xerror,
+                                                          yerror,
+                                                          zerror),
+                                            expand_errors(xerrorplus,
+                                                          yerrorplus,
+                                                          zerrorplus),
+                                            expand_errors(xerrorminus,
+                                                          yerrorminus,
+                                                          zerrorminus),
+                                            meta))
 end
 
 """
     $SIGNATURES
 
-Return new coordinates, inserting [`EmptyLine`](@ref) after every `stride`
-lines.
+Return new coordinates, inserting [`nothing`](@ref) after every `stride` lines.
 """
 function insert_scanlines(coordinates::Coordinates{N}, stride) where N
-    data = Vector{Union{EmptyLine, Coordinate{N}}}()
+    data = Vector{Union{Nothing, Coordinate{N}}}()
     for (i, coordinate) in enumerate(coordinates.data)
         push!(data, coordinate)
         if i % stride == 0
-            push!(data, EmptyLine())
+            push!(data, nothing)
         end
     end
     Coordinates(data)
@@ -254,11 +263,13 @@ function Coordinates(x::AbstractVector, y::AbstractVector, z::AbstractMatrix;
                      length(x))
 end
 
+print_tex(io::IO, ::Nothing, ::Coordinates) = println(io)
+
 function print_tex(io::IO, coordinates::Coordinates)
     println(io, "coordinates {")
     print_indent(io) do io
         for coordinate in coordinates.data
-            print_tex(io, coordinate)
+            print_tex(io, coordinate, coordinates)
         end
     end
     println(io, "}")

--- a/src/axiselements.jl
+++ b/src/axiselements.jl
@@ -97,7 +97,7 @@ Coordinate(x::CoordinateType, y::CoordinateType, z; args...) =
 function print_tex(io::IO, data::NTuple{N, CoordinateType}, ::Coordinate) where N
     print(io, "(")
     for (i, x) in enumerate(data)
-        i == 1 || print(io, ", ")
+        i == 1 || print(io, ",")
         print(io, x)
     end
     print(io, ")")
@@ -642,7 +642,7 @@ an axis, its position is irrelevant.
 Legend(labels::AbstractString...) = Legend(collect(String, labels))
 
 print_tex(io::IO, l::Legend) =
-    println(io, "\\legend{{", join(l.labels, "}, {"), "}}")
+    println(io, "\\legend{{", join(l.labels, "},{"), "}}")
 
 ###############
 # LegendEntry #

--- a/test/test_elements.jl
+++ b/test/test_elements.jl
@@ -8,11 +8,13 @@
 end
 
 @testset "coordinate" begin
+    # invalid coordinates
     @test_throws ArgumentError PGFPlotsX.Coordinate((1, ))    # dimension not 2 or 3
-    @test_throws ArgumentError PGFPlotsX.Coordinate((NaN, 1)) # not finite
     @test_throws ArgumentError PGFPlotsX.Coordinate((1, 2);   # can't specify both
                                               error = (0, 0), errorplus = (0, 0))
     @test_throws MethodError Coordinates((1, 2); error = (3, )) # incompatible dims
+
+    # valid forms
     @test squashed_repr_tex(PGFPlotsX.Coordinate((1, 2))) == "(1, 2)"
     @test squashed_repr_tex(PGFPlotsX.Coordinate((1, 2); error = (3, 4))) == "(1, 2) +- (3, 4)"
     @test squashed_repr_tex(PGFPlotsX.Coordinate((1, 2); errorminus = (3, 4))) ==
@@ -22,6 +24,12 @@ end
                                            errorplus = (5, 6))) ==
                                                "(1, 2) += (5, 6) -= (3, 4)"
     @test squashed_repr_tex(PGFPlotsX.Coordinate((1, 2); meta = "blue")) == "(1, 2) [blue]"
+    @test squashed_repr_tex(PGFPlotsX.Coordinate((NaN, 1))) == "(NaN, 1)"
+    @test squashed_repr_tex(PGFPlotsX.Coordinate(("a fish", 1))) == "(a fish, 1)"
+
+    # convenience constructors
+    @test Coordinate(1, 2) == Coordinate((1, 2))
+    @test Coordinate(1, 2, 3) == Coordinate((1, 2, 3))
 end
 
 @testset "coordinates and convenience constructors" begin
@@ -33,15 +41,15 @@ end
     @test Coordinates(1:2, 3:4).data == PGFPlotsX.Coordinate.([(1, 3), (2, 4)])
     # skip empty
     @test Coordinates([(2, 3), (), nothing]).data ==
-        [PGFPlotsX.Coordinate((2, 3)), EmptyLine(), EmptyLine()]
+        [PGFPlotsX.Coordinate((2, 3)), nothing, nothing]
     @test Coordinates(1:2, 3:4, (1:2)./((3:4)')).data ==
         Coordinates(Any[1, 2, NaN, 1, 2, NaN],
-                        Any[3, 3, NaN, 4, 4, NaN],
-                        Any[1/3, 2/3, NaN, 1/4, 2/4, NaN]).data
+                    Any[3, 3, NaN, 4, 4, NaN],
+                    Any[1/3, 2/3, NaN, 1/4, 2/4, NaN]).data
     # from iterables
     @test Coordinates(enumerate(3:4)).data == PGFPlotsX.Coordinate.([(1, 3), (2, 4)])
     @test Coordinates((x, 1/x) for x in -1:1).data ==
-        [PGFPlotsX.Coordinate((-1, -1.0)), EmptyLine(), PGFPlotsX.Coordinate((1, 1.0))]
+        [PGFPlotsX.Coordinate((-1, -1.0)), nothing, PGFPlotsX.Coordinate((1, 1.0))]
     let x = 1:3,
         y = -1:1,
         z = x ./ y

--- a/test/test_elements.jl
+++ b/test/test_elements.jl
@@ -15,17 +15,17 @@ end
     @test_throws MethodError Coordinates((1, 2); error = (3, )) # incompatible dims
 
     # valid forms
-    @test squashed_repr_tex(PGFPlotsX.Coordinate((1, 2))) == "(1, 2)"
-    @test squashed_repr_tex(PGFPlotsX.Coordinate((1, 2); error = (3, 4))) == "(1, 2) +- (3, 4)"
+    @test squashed_repr_tex(PGFPlotsX.Coordinate((1, 2))) == "(1,2)" # NOTE important not to have whitespace
+    @test squashed_repr_tex(PGFPlotsX.Coordinate((1, 2); error = (3, 4))) == "(1,2) +- (3,4)"
     @test squashed_repr_tex(PGFPlotsX.Coordinate((1, 2); errorminus = (3, 4))) ==
-        "(1, 2) -= (3, 4)"
+        "(1,2) -= (3,4)"
     @test squashed_repr_tex(PGFPlotsX.Coordinate((1, 2);
                                            errorminus = (3, 4),
                                            errorplus = (5, 6))) ==
-                                               "(1, 2) += (5, 6) -= (3, 4)"
-    @test squashed_repr_tex(PGFPlotsX.Coordinate((1, 2); meta = "blue")) == "(1, 2) [blue]"
-    @test squashed_repr_tex(PGFPlotsX.Coordinate((NaN, 1))) == "(NaN, 1)"
-    @test squashed_repr_tex(PGFPlotsX.Coordinate(("a fish", 1))) == "(a fish, 1)"
+                                               "(1,2) += (5,6) -= (3,4)"
+    @test squashed_repr_tex(PGFPlotsX.Coordinate((1, 2); meta = "blue")) == "(1,2) [blue]"
+    @test squashed_repr_tex(PGFPlotsX.Coordinate((NaN, 1))) == "(NaN,1)"
+    @test squashed_repr_tex(PGFPlotsX.Coordinate(("a fish", 1))) == "(a fish,1)"
 
     # convenience constructors
     @test Coordinate(1, 2) == Coordinate((1, 2))
@@ -144,22 +144,22 @@ end
         "graphics[testopt={1}] {filename}\n"
     # coordinates, tables, and plot
     c = Coordinates([(1, 2), (3, 4)])
-    @test repr_tex(c) == "coordinates {\n    (1, 2)\n    (3, 4)\n}\n"
+    @test repr_tex(c) == "coordinates {\n    (1,2)\n    (3,4)\n}\n"
     t = Table(x = 1:2, y = 3:4)
     @test repr_tex(t) == "table[row sep={\\\\}]\n{\n    x  y  \\\\\n    1  3  \\\\\n    2  4  \\\\\n}\n"
     @test repr_tex(@pgf Plot({ no_marks }, c)) ==
-        "\\addplot[no marks]\n    coordinates {\n        (1, 2)\n        (3, 4)\n    }\n    ;\n"
+        "\\addplot[no marks]\n    coordinates {\n        (1,2)\n        (3,4)\n    }\n    ;\n"
     @test repr_tex(@pgf Plot({ no_marks }, t, "trailing")) ==
         "\\addplot[no marks]\n    table[row sep={\\\\}]\n    {\n        x  y  \\\\\n" *
         "        1  3  \\\\\n        2  4  \\\\\n    }\n    trailing\n    ;\n"
     # legend
-    @test repr_tex(Legend(["a", "b", "c"])) == "\\legend{{a}, {b}, {c}}\n"
+    @test repr_tex(Legend(["a", "b", "c"])) == "\\legend{{a},{b},{c}}\n"
     l = LegendEntry("a")
     @test repr_tex(l) == "\\addlegendentry {a}\n"
     # axis
     @test repr_tex(@pgf Axis({ optaxis }, Plot({ optplot }, c), l)) ==
         "\\begin{axis}[optaxis]\n    \\addplot[optplot]\n" *
-        "        coordinates {\n            (1, 2)\n            (3, 4)\n        }\n" *
+        "        coordinates {\n            (1,2)\n            (3,4)\n        }\n" *
         "        ;\n    \\addlegendentry {a}\n\\end{axis}\n"
 end
 


### PR DESCRIPTION
Also allow strings for coordinates, which are printed as is. With examples and tests. Fixes #59.

Other changes:

1. Remove `EmptyLine` type, use `nothing` instead.

2. Explort `Coordinate`, useful for individual coordinates. Add
convenience constructors for it.

3. Code cleanup, add and refine some documentation.

4. Add minor example for `Coordinates(enumerate(...))`, which could resolve #94.

5. Remove space after commas in lists, which caused problems with symbolic coordinates.