### PR TITLE
Tp/vertical horizontal lines

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -27,7 +27,8 @@ makedocs(
             "examples/tables.md",
             "examples/axislike.md",
             "examples/gallery.md",
-            "examples/juliatypes.md"
+            "examples/juliatypes.md",
+            "examples/convenience.md",
         ]
     ]
 )

--- a/docs/src/examples/convenience.md
+++ b/docs/src/examples/convenience.md
@@ -1,0 +1,38 @@
+# Convenience constructs
+
+```@setup pgf
+using PGFPlotsX
+savefigs = (figname, obj) -> begin
+    pgfsave(figname * ".pdf", obj)
+    run(`pdf2svg $(figname * ".pdf") $(figname * ".svg")`)
+    pgfsave(figname * ".tex", obj);
+    return nothing
+end
+```
+
+## Horizontal and vertical lines
+
+```@example pgf
+x = range(3.01; stop = 6, length = 100)
+y = @. 1/(x-3) + 3
+@pgf Axis(
+    {
+        ymin = 2.5,
+        ymax = 6,
+        xmin = 2.5
+    },
+    Plot(
+        {
+            no_marks
+        },
+        Table(x, y)
+    ),
+    HLine({ dashed, blue }, 3),
+    VLine({ dotted, red }, 3)
+)
+savefigs("hvline", ans) # hide
+```
+
+[\[.pdf\]](hvline.pdf), [\[generated .tex\]](hvline.tex)
+
+![](hvline.svg)

--- a/docs/src/man/axiselements.md
+++ b/docs/src/man/axiselements.md
@@ -86,6 +86,15 @@ julia> print_tex(Legend(["Plot A", "Plot B"]))
 \legend{{Plot A},{Plot B}}
 ```
 
+## Horizontal and vertical lines
+
+[`HLine`](@ref) and [`VLine`](@ref) have no equivalent constructs in `pgfplots`, they are provided for convenient drawing of horizontal and vertical lines. When options are used, they are passed to the TikZ function `\draw[...]`.
+
+```@docs
+HLine
+VLine
+```
+
 ## [Using LaTeX code directly](@id latex_code_strings)
 
 In case there is no type defined in this package for some construct, you can use a `String` in an axis, and it is inserted verbatim into the generated LaTeX code. [Raw string literals](https://docs.julialang.org/en/latest/manual/strings/#man-raw-string-literals-1) and the package [LaTeXStrings](https://github.com/stevengj/LaTeXStrings.jl) are useful to avoid a lot of escaping.

--- a/src/PGFPlotsX.jl
+++ b/src/PGFPlotsX.jl
@@ -14,7 +14,7 @@ using Unicode: lowercase
 export TikzDocument, TikzPicture
 export Axis, SemiLogXAxis, SemiLogYAxis, LogLogAxis, PolarAxis, GroupPlot
 export Plot, PlotInc, Plot3, Plot3Inc, Expression, Coordinate, Coordinates,
-    TableData, Table, Graphics, Legend, LegendEntry
+    TableData, Table, Graphics, Legend, LegendEntry, VLine, HLine
 export @pgf, pgfsave, print_tex, latexengine, latexengine!, push_preamble!
 
 const DEBUG = haskey(ENV, "PGFPLOTSX_DEBUG")

--- a/src/axiselements.jl
+++ b/src/axiselements.jl
@@ -674,3 +674,45 @@ function print_tex(io::IO, legendentry::LegendEntry)
     print(io, name)
     println(io, "}")
 end
+
+###################
+# VLine and HLine #
+###################
+
+struct VLine
+    options::Options
+    x::Real
+end
+
+"""
+    VLine([options], x)
+
+A vertical line at `x`.
+"""
+VLine(x::Real) = VLine(Options(), x)
+
+function print_tex(io::IO, vline::VLine)
+    @unpack options, x = vline
+    print(io, "\\draw")
+    print_options(io, options; newline = false)
+    println(io, "($(x),\\pgfkeysvalueof{/pgfplots/ymin})--($(x),\\pgfkeysvalueof{/pgfplots/ymax});")
+end
+
+struct HLine
+    options::Options
+    y::Real
+end
+
+"""
+    HLine([options], y)
+
+A horizontal vertical line at `y`.
+"""
+HLine(y::Real) = HLine(Options(), y)
+
+function print_tex(io::IO, hline::HLine)
+    @unpack options, y = hline
+    print(io, "\\draw")
+    print_options(io, options; newline = false)
+    println(io, "(\\pgfkeysvalueof{/pgfplots/xmin},$(y))--(\\pgfkeysvalueof{/pgfplots/xmax},$(y));")
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,6 +23,7 @@ mktempdir() do tmp; cd(tmp) do
     include("test_build.jl")
 end end
 
+Base.CoreLogging.disable_logging(Base.CoreLogging.Warn) # no deprecation messages
 include("../docs/make.jl")
 
 # Run doc stuff, turn off deprecations (this doesn't seem to work on .travis)

--- a/test/test_elements.jl
+++ b/test/test_elements.jl
@@ -186,3 +186,10 @@ end
     append!(document, ["stuff"])
     @test document.elements == [picture, "stuff"]
 end
+
+@testset "vertical and horizontal lines" begin
+    @test repr_tex((@pgf VLine({blue}, 9))) ==
+        "\\draw[blue] (9,\\pgfkeysvalueof{/pgfplots/ymin})--(9,\\pgfkeysvalueof{/pgfplots/ymax});\n"
+    @test repr_tex((@pgf HLine({dashed}, 4.0))) ==
+        "\\draw[dashed] (\\pgfkeysvalueof{/pgfplots/xmin},4.0)--(\\pgfkeysvalueof{/pgfplots/xmax},4.0);\n"
+end


### PR DESCRIPTION
Introduce HLine and VLine for vertical and horizontal lines, fixing #90.

Also, disable warnings for docs generation, to get rid of deprecation warnings.