### PR TITLE
Fix juno integration

### DIFF
--- a/src/requires.jl
+++ b/src/requires.jl
@@ -82,13 +82,4 @@ function __init__()
                                   histogram.weights)
         end
     end
-
-    @require Juno="e5e0dc1b-0480-54bc-9374-aad01c23163d" begin
-        Juno.Media.media(_SHOWABLE, Juno.Media.Plot)
-        function Juno.Media.render(pane::Juno.PlotPane, p::_SHOWABLE)
-            f = tempname() * ((!_JUNO_PNG && HAVE_PDFTOSVG) ? ".svg" : ".png")
-            save(f, p; dpi = _JUNO_DPI, showing_ide=true)
-            Juno.Media.render(pane, HTML("<div><img src=\"$f\" /></div>"))
-        end
-    end
 end

--- a/src/tikzdocument.jl
+++ b/src/tikzdocument.jl
@@ -288,11 +288,6 @@ if HAVE_PDFTOSVG
     end
 end
 
-_JUNO_PNG = false
-_JUNO_DPI = 150
-show_juno_png(v::Bool) = global _JUNO_PNG = v
-dpi_juno_png(dpi::Int) = global _JUNO_DPI = dpi
-
 if HAVE_PDFTOPPM
     function savepng(filename::String, td::TikzDocument;
                      latex_engine = latexengine(),
@@ -336,12 +331,11 @@ end
 _DISPLAY_PDF = true
 enable_interactive(v::Bool) = global _DISPLAY_PDF = v
 _is_ijulia() = isdefined(Main, :IJulia) && Main.IJulia.inited
-_is_juno()   = isdefined(Main, :Juno) && Main.Juno.isactive()
 _is_vscode() = isdefined(Main, :_vscodeserver)
-_is_ide()    = _is_ijulia() || _is_juno() || _is_vscode()
+_is_ide()    = _is_ijulia() || _is_vscode()
 
 function Base.show(io::IO, ::MIME"text/plain", p::_SHOWABLE)
-    if isinteractive() && _DISPLAY_PDF && !_is_ijulia() && !_is_juno() && isdefined(Base, :active_repl)
+    if isinteractive() && _DISPLAY_PDF && !_is_ijulia() && isdefined(Base, :active_repl)
         filename = tempname() .* ".pdf"
         save(filename, p)
         try


### PR DESCRIPTION
All of that [isn't necessary anymore with Juno 0.7](http://docs.junolab.org/latest/man/info_developer.html#Displaying-Plots-and-Graphics-1).

There still is a problem here in that everything will be displayed in Juno *and* in an external pdf viewer. Imho this package should register it's own `PGFPlotsXDisplay <: AbstractDisplay` instead of overloading `show(io, ::MIME"text/plain", p)` to have those side effects (similar to https://github.com/JuliaPlots/Plots.jl/pull/1667).