### PR TITLE
Add support for Date and DateTime, with documentation and tests.

### DIFF
--- a/docs/src/examples/juliatypes.md
+++ b/docs/src/examples/juliatypes.md
@@ -24,7 +24,7 @@ relative_irradiance(d) = (1 + 0.034*cospi(2*Dates.dayofyear(d)/365.25))
 @pgf Axis(
     {
         date_coordinates_in = "x",
-        "x tick label style" = "{rotate=90}",
+        x_tick_label_style = "{rotate=90}",
         xlabel = "date",
         ylabel = "relative solar irradiance",
     },

--- a/docs/src/examples/juliatypes.md
+++ b/docs/src/examples/juliatypes.md
@@ -12,6 +12,34 @@ savefigs = (figname, obj) -> begin
 end
 ```
 
+## Dates
+
+`Dates` is a standard library in Julia. `Date` and `DateTime` types are supported natively, but you should specify the `date_coordinates_in = ...` option in your plot for the relevant axes.
+
+```@example pgf
+using Dates
+dategrid = Date(2000,1,1):Day(1):Date(2000,12,31)
+relative_irradiance(d) = (1 + 0.034*cospi(2*Dates.dayofyear(d)/365.25))
+
+@pgf Axis(
+    {
+        date_coordinates_in = "x",
+        "x tick label style" = "{rotate=90}",
+        xlabel = "date",
+        ylabel = "relative solar irradiance",
+    },
+    Plot(
+    {
+        no_marks
+    },
+    Table(dategrid, relative_irradiance.(dategrid))))
+savefigs("dates", ans) # hide
+```
+
+[\[.pdf\]](dates.pdf), [\[generated .tex\]](dates.tex)
+
+![](dates.svg)
+
 ## Colors.jl
 
 ### LineColor

--- a/src/PGFPlotsX.jl
+++ b/src/PGFPlotsX.jl
@@ -4,6 +4,7 @@ import MacroTools: prewalk, @capture, @forward
 
 using ArgCheck: @argcheck
 using DataStructures: OrderedDict
+using Dates
 import DefaultApplication
 using DocStringExtensions: SIGNATURES, TYPEDEF
 using Parameters: @unpack
@@ -81,6 +82,10 @@ function print_tex(io::IO, x::Real)
 end
 
 print_tex(io::IO, ::Missing) = print(io, "nan")
+
+print_tex(io::IO, dt::Date) = Dates.format(io, dt, dateformat"YYYY-mm-dd")
+
+print_tex(io::IO, dt::DateTime) = Dates.format(io, dt, dateformat"YYYY-mm-dd HH:MM")
 
 print_tex(io::IO,   v) = throw(ArgumentError(string("No tex function available for data of type $(typeof(v)). ",
                                                   "Define one by overloading print_tex(io::IO, data::T) ",

--- a/src/build.jl
+++ b/src/build.jl
@@ -67,13 +67,14 @@ The default preamble for LaTeX documents. Don't change this, customize
 [`CUSTOM_PREAMBLE`](@ref) instead.
 """
 DEFAULT_PREAMBLE =
-String[
-"\\usepackage{pgfplots}",
-"\\pgfplotsset{compat=newest}",
-"\\usepgfplotslibrary{groupplots}",
-"\\usepgfplotslibrary{polar}",
-"\\usepgfplotslibrary{statistics}",
-]
+    String[
+        "\\usepackage{pgfplots}",
+        "\\pgfplotsset{compat=newest}",
+        "\\usepgfplotslibrary{groupplots}",
+        "\\usepgfplotslibrary{polar}",
+        "\\usepgfplotslibrary{statistics}",
+        "\\usepgfplotslibrary{dateplot}",
+    ]
 
 # Collects the full preamble from the different sources, default and custom
 function _default_preamble()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,7 @@ using PGFPlotsX: Options
 using Colors
 using Contour
 using DataFrames
+using Dates
 using LaTeXStrings
 
 if get(ENV, "CI", false) == true

--- a/test/test_elements.jl
+++ b/test/test_elements.jl
@@ -5,6 +5,8 @@
     @test squashed_repr_tex(Inf) == "+inf"
     @test squashed_repr_tex(-Inf) == "-inf"
     @test squashed_repr_tex(missing) == "nan"
+    @test squashed_repr_tex(Date(2000, 1, 2)) == "2000-01-02"
+    @test squashed_repr_tex(DateTime(2000, 1, 2, 3, 4)) == "2000-01-02 03:04"
 end
 
 @testset "coordinate" begin


### PR DESCRIPTION
Puts the relevant `pgfplots` library by default (in the preamble), I think this is reasonable as `Dates` is a standard library and plotting dates is common. I found the slowdown insignificant.