### PR TITLE
standalone class options

### DIFF
--- a/docs/src/man/save.md
+++ b/docs/src/man/save.md
@@ -48,6 +48,13 @@ There are a few ways to do this:
 PGFPlotsX.CUSTOM_PREAMBLE
 ```
 
+Access to the class options of the standalone document class is possible with
+[`PGFPlotsX.CLASS_OPTIONS`](@ref).
+
+```@docs
+PGFPlotsX.CLASS_OPTIONS
+```
+
 ## Choosing the LaTeX engine used
 
 Thee are two different choices for latex engines, `PDFLATEX`, `LUALATEX`.

--- a/src/tikzdocument.jl
+++ b/src/tikzdocument.jl
@@ -105,6 +105,17 @@ end
 
 _OLD_LUALATEX = false
 
+"""
+List of class options used in the preamble (default ["tikz"]).
+
+By setting
+`PGFPlotsX.CLASS_OPTIONS[1] = "varwidth"; push!(PGFPlotsX.CLASS_OPTIONS, "crop=false")`
+the preamble will contain `documentclass[varwidth,crop=false]{standalone}`.
+
+See https://www.ctan.org/pkg/standalone for a list of options.
+"""
+CLASS_OPTIONS = ["tikz"]
+
 savetex(io::IO, td::TikzDocument; include_preamble::Bool = true) =
     print_tex(io, td; include_preamble = include_preamble)
 
@@ -119,7 +130,7 @@ function print_tex(io::IO, td::TikzDocument; include_preamble::Bool = true)
             println(io, "\\RequirePackage{luatex85}")
         end
         # Temp workaround for CI
-        println(io, "\\documentclass[tikz]{standalone}")
+        println(io, "\\documentclass[$(join(CLASS_OPTIONS, ','))]{standalone}")
         if use_default_preamble
             preamble = vcat(_default_preamble(), preamble)
         end

--- a/src/tikzdocument.jl
+++ b/src/tikzdocument.jl
@@ -106,7 +106,7 @@ end
 _OLD_LUALATEX = false
 
 """
-List of class options used in the preamble (default ["tikz"]).
+List of class options used in the preamble (default `["tikz"]`).
 
 By setting
 `PGFPlotsX.CLASS_OPTIONS[1] = "varwidth"; push!(PGFPlotsX.CLASS_OPTIONS, "crop=false")`

--- a/test/test_build.jl
+++ b/test/test_build.jl
@@ -126,3 +126,19 @@ end
         end
     end
 end
+
+@testset "class options" begin
+    tmp_pdf = tempname() * ".pdf"
+    mktempdir() do dir
+        cd(dir) do
+            PGFPlotsX.CLASS_OPTIONS[1] = "varwidth"
+            push!(PGFPlotsX.CLASS_OPTIONS, "crop = false")
+            td = TikzDocument("\\begin{tabular}{cc}",
+                              TikzPicture(Axis(Plot(Expression("x^2")))),
+                              "& A \\end{tabular}")
+            pgfsave(tmp_pdf, td)
+            @test is_pdf_file(tmp_pdf)
+            rm(tmp_pdf)
+        end
+    end
+end


### PR DESCRIPTION
The example in the test would throw an error without a change of the class options.