### PR TITLE
Use a project for coverage.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ deps/deps.jl
 deps/pdf2svg.svg
 deps/showed_warning
 /Manifest.toml
+/test/coverage/Manifest.toml

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,4 +29,5 @@ script:
 after_success:
   # push coverage results to Coveralls, .cov files were copied back by script above
   - echo "**** submitting coverage information"
-  - julia -e 'import Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
+  - julia --project=test/coverage -e 'using Pkg; Pkg.instantiate();
+        using Coverage; Codecov.submit(Codecov.process_folder())'

--- a/test/coverage/Project.toml
+++ b/test/coverage/Project.toml
@@ -1,0 +1,2 @@
+[deps]
+Coverage = "a2441757-f6aa-5fb2-8edb-039e3f45d037"


### PR DESCRIPTION
Should fix the file permission error on master (https://travis-ci.org/KristofferC/PGFPlotsX.jl/jobs/505675756#L907) since we use a different manifest. Also no point in adding coverage to the main `Project.toml`.