### PR TITLE
Allow explicit surface colors.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -20,9 +20,9 @@ Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 julia = "1"
 
 [extras]
+Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Measurements = "eff96d63-e80a-5855-80a2-b1b0885c5ab7"
-Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]

--- a/docs/src/examples/juliatypes.md
+++ b/docs/src/examples/juliatypes.md
@@ -106,6 +106,37 @@ savefigs("colormap", td) # hide
 
 ![](colormap.svg)
 
+### Explicit colors in surface plots
+
+When used outside options, all `Colors.Colorant` colors are printed in the format that can be used in surface plots explicitly.
+
+```@example pgf
+using Colors
+hues = 0:30:360
+saturations = 0:0.1:1
+HS = vec(tuple.(hues, saturations'))
+c = Coordinates(first.(HS), last.(HS); meta = [HSL(hs..., 0.5) for hs in HS])
+@pgf Axis(
+    {
+        enlargelimits = false,
+        xlabel = "hue (degrees)",
+        ylabel = "saturation"
+    },
+    Plot(
+        {
+            "matrix_plot*",
+            no_marks,
+            "mesh/color input" = "explicit",
+            "mesh/cols" = length(hues)
+        },
+        c))
+savefigs("explicit_surface_color", ans) # hide
+```
+
+[\[.pdf\]](explicit_surface_color.pdf), [\[generated .tex\]](explicit_surface_color.tex)
+
+![](explicit_surface_color.svg)
+
 ### ggplot2
 
 Something that looks a bit like ggplot2.

--- a/src/axiselements.jl
+++ b/src/axiselements.jl
@@ -104,7 +104,7 @@ function print_tex(io::IO, data::NTuple{N, CoordinateType}, ::Coordinate) where 
 end
 
 # Print raw strings inside coordinates. Compared to generic `print_tex`, print no newline,
-# this requires that tokens are separates in some other way (eg brackets).
+# this requires that tokens are separated in some other way (eg containing brackets).
 print_tex(io::IO, str::AbstractString, ::Coordinate) = print(io, str)
 
 function print_tex(io::IO, coordinate::Coordinate)

--- a/src/axiselements.jl
+++ b/src/axiselements.jl
@@ -103,6 +103,10 @@ function print_tex(io::IO, data::NTuple{N, CoordinateType}, ::Coordinate) where 
     print(io, ")")
 end
 
+# Print raw strings inside coordinates. Compared to generic `print_tex`, print no newline,
+# this requires that tokens are separates in some other way (eg brackets).
+print_tex(io::IO, str::AbstractString, ::Coordinate) = print(io, str)
+
 function print_tex(io::IO, coordinate::Coordinate)
     @unpack data, error, errorplus, errorminus, meta = coordinate
     print_tex(io, data, coordinate)
@@ -117,7 +121,7 @@ function print_tex(io::IO, coordinate::Coordinate)
     _print_error("-=", errorminus)
     if meta ≠ nothing
         print(io, " [")
-        print(io, meta)
+        print_tex(io, meta, coordinate)
         print(io, "]")
     end
     println(io)

--- a/src/requires.jl
+++ b/src/requires.jl
@@ -17,15 +17,24 @@ function __init__()
     @require Colors="5ae59095-9a9b-59fe-a467-6f913c188581" begin
         function _rgb_for_printing(c::Colors.Colorant)
             rgb = convert(Colors.RGB{Float64}, c)
-            round.((Colors.red(rgb), Colors.green(rgb), Colors.blue(rgb)); digits = 4) # somewhat arbitrary choice of accuracy
+            # round colors since pgfplots cannot parse scientific notation, eg 1e-10
+            round.((Colors.red(rgb), Colors.green(rgb), Colors.blue(rgb)); digits = 4)
         end
 
-        function PGFPlotsX.print_tex(io::IO, c::Colors.Colorant)
+        function PGFPlotsX.print_opt(io::IO, c::Colors.Colorant)
             rgb_64 = _rgb_for_printing(c)
             print(io, "rgb,1:",
                   "red,"  , rgb_64[1], ";",
                   "green,", rgb_64[2], ";",
                   "blue," , rgb_64[3])
+        end
+
+        # For printing surface plots with explicit color, pgfplots manual 4.6.7.
+        # If there are any other uses outside options that need a different format,
+        # we should introduce a wrapper type.
+        function PGFPlotsX.print_tex(io::IO, c::Colors.Colorant)
+            rgb_64 = _rgb_for_printing(c)
+            print(io, "rgb=", rgb_64[1], ",", rgb_64[2], ",", rgb_64[3])
         end
 
         function PGFPlotsX.print_tex(io::IO, c::Tuple{String, Colors.Colorant}, ::Any)

--- a/test/test_elements.jl
+++ b/test/test_elements.jl
@@ -68,6 +68,10 @@ end
         @test Coordinates([1.0, 2.0], y).data ==
             Coordinates([1.0, 2.0], [3.0, 4.0], yerror = [0.3, 0.4]).data
     end
+
+    # meta printing
+    @test squashed_repr_tex(Coordinates([1], [1]; meta = [RGB(0.1, 0.2, 0.3)])) ==
+        "coordinates {\n(1,1) [rgb=0.1,0.2,0.3]\n}"
 end
 
 @testset "tables" begin
@@ -207,8 +211,8 @@ end
 end
 
 @testset "colors" begin
-    @test squashed_repr_tex(@pgf { color = RGB(1e-10, 1, 1) }) == 
+    @test squashed_repr_tex(@pgf { color = RGB(1e-10, 1, 1) }) ==
         "[color={rgb,1:red,0.0;green,1.0;blue,1.0}]"
-    @test squashed_repr_tex(@pgf { color = HSV(1, 1e-10, 1) }) == 
+    @test squashed_repr_tex(@pgf { color = HSV(1, 1e-10, 1) }) ==
         "[color={rgb,1:red,1.0;green,1.0;blue,1.0}]"
 end


### PR DESCRIPTION
1. make meta in coordinates print via `print_tex`, without new line when specified as a raw string,

2. revert using `print_tex` for standalone colors in #158, use for another `print_tex` method

3. add example matrix surface plot

4. incidental whitespace fixes.

Fixes #153.

@yakir12: I had to narrow the `print_tex` method back to `print_opt` for this, reverting a change in #158. Was there a specific reason for that? It seems fine to me this way.