### PR TITLE
Special case SemiLogXAxis, SemiLogYAxis and LogLogAxis in GroupPlot

### DIFF
--- a/docs/src/examples/axislike.md
+++ b/docs/src/examples/axislike.md
@@ -68,29 +68,29 @@ savefigs("groupplot-multiple", ans) # hide
 
 ![](groupplot-multiple.svg)
 
-## Using `Axis` in group plots
+## Using `Axis` etc in group plots
 
-Alternatively, you can use `Axis` to group together options and a set of plots. This makes it easier to combine existing plots into a grouped plot.
+Alternatively, you can use `Axis`, `SemiLogXAxis`, `SemiLogYAxis` and `LogLogAxis` to group together options and a set of plots. This makes it easier to combine existing plots into a grouped plot.
 
 ```@example pgf
-x = range(0; stop =2*pi, length = 100)
-axs1 = @pgf Axis({ xlabel = raw"$\alpha$", ylabel = "sin" },
-                 PlotInc(Table(x, sin.(x))),
-                 PlotInc(Table(x, sin.(x .+ 0.5))));
-axs2 = @pgf Axis({ xlabel = raw"$\beta$", ylabel = "cos" },
-                  PlotInc(Table(x, cos.(x))),
-                  PlotInc(Table(x, cos.(x .+ 0.5))));
+x = range(0; stop=2, length = 100)
+exp_plot = PlotInc(Table(x, exp.(x)))
+exp_legend = LegendEntry(raw"$\exp(x)$")
+log_plot = PlotInc(Table(x, log.(x)))
+log_legend = LegendEntry(raw"$\log(x)$")
+
+axs1 = @pgf Axis(exp_plot, exp_legend, log_plot, log_legend)
+axs2 = @pgf SemiLogYAxis(exp_plot, exp_legend, log_plot, log_legend)
+axs3 = @pgf SemiLogXAxis(exp_plot, exp_legend, log_plot, log_legend)
+axs4 = @pgf LogLogAxis(exp_plot, exp_legend, log_plot, log_legend)
+
 @pgf GroupPlot(
-    {
-        group_style =
-        {
-            group_size="2 by 1",
-            xticklabels_at="edge bottom",
-            yticklabels_at="edge left"
-        },
-        no_markers
+    { group_style = { group_size="2 by 2" },
+      no_markers,
+      legend_pos="north west",
+      xlabel=raw"$x$",
     },
-    axs1, axs2)
+    axs1, axs2, axs3, axs4)
 savefigs("groupplot-multiple-axis", ans) # hide
 ```
 

--- a/src/axislike.jl
+++ b/src/axislike.jl
@@ -112,7 +112,8 @@ The `contents` after the global options are processed as follows:
 
 2. `nothing` is emitted as a `\\nextgroupplot[group/empty plot]`,
 
-3. an [`Axis`](@ref) is emitted as a `\\nextgroupplot[options...]`, followed by the contents,
+3. [`Axis`](@ref), [`SemiLogXAxis`](@ref), [`SemiLogYAxis`](@ref) and [`LogLogAxis`](@ref)
+   are emitted as `\\nextgroupplot[options...]`, followed by the contents,
 
 4. other values, eg `Plot` are emitted using [`print_tex`](@ref).
 """
@@ -128,9 +129,18 @@ function print_tex(io::IO, groupplot::GroupPlot)
             if elt isa Options
                 print(io, raw"\nextgroupplot")
                 print_options(io, elt)
-            elseif elt isa Axis
+            elseif typeof(elt) in (Axis, SemiLogXAxis, SemiLogYAxis, LogLogAxis)
                 print(io, raw"\nextgroupplot")
-                print_options(io, elt.options)
+                # add extra option for SemiLogXAxis, SemiLogYAxis, LogLogAxis
+                opts = elt.options
+                if elt isa SemiLogXAxis
+                    opts = merge(Options("xmode=log,ymode=normal" => nothing), opts)
+                elseif elt isa SemiLogYAxis
+                    opts = merge(Options("xmode=normal,ymode=log" => nothing), opts)
+                elseif elt isa LogLogAxis
+                    opts = merge(Options("xmode=log,ymode=log" => nothing), opts)
+                end
+                print_options(io, opts)
                 for c in elt.contents
                     print_tex(io, c)
                 end

--- a/test/test_elements.jl
+++ b/test/test_elements.jl
@@ -216,3 +216,16 @@ end
     @test squashed_repr_tex(@pgf { color = HSV(1, 1e-10, 1) }) ==
         "[color={rgb,1:red,1.0;green,1.0;blue,1.0}]"
 end
+
+@testset "Axis, SemiLogXAxis, SemiLogYAxis and LogLogAxis inside GroupPlot" begin
+    gp = @pgf GroupPlot({group_style={group_size="2 by 2"}},
+        Axis(), SemiLogXAxis(), SemiLogYAxis(), LogLogAxis())
+    @test repr_tex(gp) == """
+    \\begin{groupplot}[group style={group size={2 by 2}}]
+        \\nextgroupplot
+        \\nextgroupplot[xmode=log,ymode=normal]
+        \\nextgroupplot[xmode=normal,ymode=log]
+        \\nextgroupplot[xmode=log,ymode=log]
+    \\end{groupplot}
+    """
+end


### PR DESCRIPTION
Special case `SemiLogXAxis`, `SemiLogYAxis` and `LogLogAxis` in `GroupPlot` in the same way as `Axis` already is special cased.