### PR TITLE
Use pdftocairo as an alternative to pdf2svg and pdftopnm

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -40,7 +40,6 @@ else
     if have_pdftoppm
         default_pdftoppm = `pdftoppm`
     else
-        have_pdftoppm
         @warn(string("Did not find `pdftocairo` or `pdftoppm`, png output will be disabled. Install `pdftocairo` or `pdftoppm` ",
                     "and run Pkg.build(\"PGFPLotsX\") to enable"))
     end
@@ -66,9 +65,13 @@ end
 open(joinpath(@__DIR__, "deps.jl"), "w") do f
     println(f, "DEFAULT_ENGINE = \"", default_engine, "\"")
     println(f, "HAVE_PDFTOPPM = ", have_pdftoppm)
-    println(f, "DEFAULT_PDFTOPPM = ", default_pdftoppm)
+    if have_pdftoppm
+        println(f, "DEFAULT_PDFTOPPM = ", default_pdftoppm)
+    end
     println(f, "HAVE_PDFTOSVG = ", have_pdf2svg)
-    println(f, "DEFAULT_PDFTOSVG = ", default_pdftosvg)
+    if have_pdf2svg
+        println(f, "DEFAULT_PDFTOSVG = ", default_pdftosvg)
+    end
 end
 
 

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -24,33 +24,51 @@ else
                  "the correct paths are set then run Pkg.build(\"PGFPLotsX\")"))
 end
 
-print(stderr, "Looking for pdftoppm...")
-have_pdftoppm =  try success(`pdftoppm  -v`); catch; false; end
-println(stderr, "   ", have_pdftoppm ? OK : X)
-if !have_pdftoppm
-    @warn(string("Did not find `pdftoppm`, png output will be disabled. Install `pdftoppm` ",
-                "and run Pkg.build(\"PGFPLotsX\") to enable"))
+print(stderr, "Looking for pdftocairo...")
+have_pdftocairo =  try success(`pdftocairo  -v`); catch; false; end
+println(stderr, "   ", have_pdftocairo ? OK : X)
+
+if have_pdftocairo
+    have_pdftoppm = true
+    default_pdftoppm = `pdftocairo`
+    have_pdf2svg = true
+    default_pdftosvg = `pdftocairo -svg -l 1`
+else
+    print(stderr, "Looking for pdftoppm...")
+    have_pdftoppm =  try success(`pdftoppm  -v`); catch; false; end
+    println(stderr, "   ", have_pdftoppm ? OK : X)
+    if have_pdftoppm
+        default_pdftoppm = `pdftoppm`
+    else
+        have_pdftoppm
+        @warn(string("Did not find `pdftocairo` or `pdftoppm`, png output will be disabled. Install `pdftocairo` or `pdftoppm` ",
+                    "and run Pkg.build(\"PGFPLotsX\") to enable"))
+    end
+
+    print(stderr, "Looking for pdf2svg...")
+    pdfpath = joinpath(@__DIR__, "pdf2svg.pdf")
+    svgpath = joinpath(@__DIR__, "pdf2svg.svg")
+    have_pdf2svg = try success(`pdf2svg $pdfpath $svgpath`); catch; false; end
+    println(stderr, "    ", have_pdf2svg ? OK : X)
+    if have_pdf2svg
+        default_pdftosvg = `pdf2svg`
+    else
+        @warn(string("Did not find `pdftocairo` or `pdf2svg`, svg output will be disabled. Install `pdftocairo` or `pdf2svg` ",
+                    "and run Pkg.build(\"PGFPLotsX\") to enable"))
+    end
 end
 
-print(stderr, "Looking for pdf2svg...")
-pdfpath = joinpath(@__DIR__, "pdf2svg.pdf")
-svgpath = joinpath(@__DIR__, "pdf2svg.svg")
-have_pdf2svg = try success(`pdf2svg $pdfpath $svgpath`); catch; false; end
-println(stderr, "    ", have_pdf2svg ? OK : X)
-if !have_pdf2svg
-    @warn(string("Did not find `pdf2svg`, svg output will be disabled. Install `pdf2svg` ",
-                "and run Pkg.build(\"PGFPLotsX\") to enable"))
-end
-
-if !have_pdf2svg && !have_pdftoppm
-    @warn(string("Found neither pdf2svg or pdftoppm, figures will not be viewable in Jupyter or Juno"))
+if !have_pdftocairo && !have_pdf2svg && !have_pdftoppm
+    @warn(string("Found none of pdftocairo, pdf2svg, or pdftoppm; figures will not be viewable in Jupyter or Juno"))
 end
 
 
 open(joinpath(@__DIR__, "deps.jl"), "w") do f
     println(f, "DEFAULT_ENGINE = \"", default_engine, "\"")
     println(f, "HAVE_PDFTOPPM = ", have_pdftoppm)
+    println(f, "DEFAULT_PDFTOPPM = ", default_pdftoppm)
     println(f, "HAVE_PDFTOSVG = ", have_pdf2svg)
+    println(f, "DEFAULT_PDFTOSVG = ", default_pdftosvg)
 end
 
 

--- a/src/tikzdocument.jl
+++ b/src/tikzdocument.jl
@@ -273,7 +273,7 @@ if HAVE_PDFTOSVG
             Ijulia_cache[[1,2]] = [hsh, tmp_ijulia_pdf]
         end
         # TODO Better error
-        svg_cmd = `pdf2svg $tmp_pdf $filename`
+        svg_cmd = `$DEFAULT_PDFTOSVG $tmp_pdf $filename`
         svg_success = success(svg_cmd)
         if !svg_success
             error("Failed to run $svg_cmd")
@@ -330,7 +330,7 @@ if HAVE_PDFTOPPM
             savepdf(tmp, td, latex_engine = latex_engine, buildflags = buildflags)
         end
         filebase = splitext(filename)[1]
-        png_cmd = `pdftoppm -png -r $dpi -singlefile $tmp $filebase`
+        png_cmd = `$DEFAULT_PDFTOPPM -png -r $dpi -singlefile $tmp $filebase`
         png_success = success(png_cmd)
         found_ijulia_cache_matching && rm(tmp; force=true)
         if !png_success


### PR DESCRIPTION
Add `pdftocairo` as the preferred converter for PDF -> SVG and PDF -> PNG. It comes as part of the poppler utilities and is generally better maintained and more reliable than `pdf2svg` (I am the author of `pdf2svg` :smile: ).