### PR TITLE
Define print_tex(String, ...), also for options.

### DIFF
--- a/src/PGFPlotsX.jl
+++ b/src/PGFPlotsX.jl
@@ -40,11 +40,20 @@ include("../deps/deps.jl")
 Print `elt` to `io` as LaTeX code. The optional third argument allows methods to
 work differently depending on the container.
 
+`print_tex(String, ...)` returns the LaTeX code as a `String`.
+
 This method should indent as if at the top level, containers indent their
 contents as necessary. See [`print_indent`](@ref).
 """
 print_tex(io::IO, a, b) = print_tex(io, a)
+
 print_tex(a) = print_tex(stdout, a)
+
+function print_tex(::Type{String}, args...)
+    io = IOBuffer()
+    print_tex(io, args...)
+    String(take!(io))
+end
 
 include("options.jl")
 include("utilities.jl")

--- a/src/options.jl
+++ b/src/options.jl
@@ -107,11 +107,14 @@ function Base.merge!(a::OptionType, options::Options)
 end
 
 """
-    $SIGNATURES
+    $(SIGNATURES)
 
 Print options between `[]`. For each option, the value is printed using
 [`print_opt`](@ref). Unless `newline == true` (the default), a newline follows
 the `]`, otherwise a space.
+
+Note that you can also use `print_tex` for this purpose, in which case a newline is not
+printed.
 """
 function print_options(io::IO, options::Options; newline = true)
     @unpack dict, print_empty = options
@@ -124,6 +127,8 @@ function print_options(io::IO, options::Options; newline = true)
     end
     newline ? println(io) : print(io, " ")
 end
+
+print_tex(io::IO, options::Options) = print_options(io, options; newline = false)
 
 accum_opt!(d::AbstractDict, opt::String) = d[opt] = nothing
 accum_opt!(d::AbstractDict, opt::Pair) = d[first(opt)] = last(opt)

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -1,17 +1,7 @@
 # utilities for testing
 
 "Invoke print_tex with the given arguments, collect the results in a string."
-function repr_tex(args...)
-    io = IOBuffer()
-    print_tex(io, args...)
-    String(take!(io))
-end
-
-function repr_tex(options::Options)
-    io = IOBuffer()
-    PGFPlotsX.print_options(io, options; newline = false)
-    String(take!(io))
-end
+repr_tex(args...) = print_tex(String, args...)
 
 """
 Trim lines, merge whitespace to a single space, merge multiple empty lines into


### PR DESCRIPTION
This is a minor simplification in case the user wants to obtain the LaTeX output without manually creating, filling, and capturing an `IOBuffer`.