### PR TITLE
Add print_tex for vectors, example with \node.

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -29,6 +29,7 @@ makedocs(
             "examples/gallery.md",
             "examples/juliatypes.md",
             "examples/convenience.md",
+            "examples/latex.md",
         ]
     ]
 )

--- a/docs/src/examples/latex.md
+++ b/docs/src/examples/latex.md
@@ -1,0 +1,49 @@
+# [Using LaTeX code](@id latex-code)
+
+PGFPlotsX has does not specify types for all LaTeX constructs. This is not a limitation, as you can just provide LaTeX code as strings, which are emitted directly. They can be freely mixed with other types, which are converted to LaTeX with [`print_tex`](@ref). Since elements of `AbstractVector`s are printed in turn, this allows for a compact style.
+
+```@setup pgf
+using PGFPlotsX
+savefigs = (figname, obj) -> begin
+    pgfsave(figname * ".pdf", obj)
+    run(`pdf2svg $(figname * ".pdf") $(figname * ".svg")`)
+    pgfsave(figname * ".tex", obj);
+    return nothing
+end
+```
+
+## Annotating plots
+
+The example below demonstrates the use of `\node`. Note the following:
+
+- we use the `raw` string literal, which ensures that we don't need to escape the `\`; `"\\node"` would work identically
+
+- the options (with `{}`, also containing a color) and coordinates we mix in just work as they should,
+
+- we provide separating whitespace, and the terminating `;`.
+
+```@example pgf
+using Colors
+x = vcat(randn(10) ./ 4, 2.0)
+y = vcat(randn(10) ./ 4, 1.0)
+@pgf Axis(
+    {
+        only_marks,
+        xlabel = "x",
+        ylabel = "y"
+    },
+    Plot(Table(x, y)),
+    [raw"\node ",
+     {
+         draw = parse(Colorant, "tomato3"),
+         pin = "180:outlier"
+     },
+     " at ",
+     Coordinate(x[end], y[end]),
+     "{};"])
+savefigs("annotated-node", ans) # hide
+```
+
+[\[.pdf\]](annotated-node.pdf), [\[generated .tex\]](annotated-node.tex)
+
+![](annotated-node.svg)

--- a/docs/src/man/axiselements.md
+++ b/docs/src/man/axiselements.md
@@ -98,3 +98,5 @@ VLine
 ## [Using LaTeX code directly](@id latex_code_strings)
 
 In case there is no type defined in this package for some construct, you can use a `String` in an axis, and it is inserted verbatim into the generated LaTeX code. [Raw string literals](https://docs.julialang.org/en/latest/manual/strings/#man-raw-string-literals-1) and the package [LaTeXStrings](https://github.com/stevengj/LaTeXStrings.jl) are useful to avoid a lot of escaping.
+
+[The gallery](@ref latex-code) has some detailed examples, eg for annotating plots.

--- a/src/PGFPlotsX.jl
+++ b/src/PGFPlotsX.jl
@@ -73,6 +73,14 @@ Print a string *as is*, terminated with a newline.
 print_tex(io::IO, str::AbstractString) = println(io, str)
 
 """
+$(SIGNATURES)
+
+Vectors are emitted elementwise without any extra whitespace as LaTeX code, using the
+`print_tex` method for each element.
+"""
+print_tex(io::IO, vector::AbstractVector) = foreach(elt -> print_tex(io, elt), vector)
+
+"""
     $SIGNATURES
 
 Real numbers are printed as is, except for non-finite representation.


### PR DESCRIPTION
Something like this is the best solution to #36 I can think of, suggestions welcome.