### PR TITLE
make PlotData an abstract type

### DIFF
--- a/src/axiselements.jl
+++ b/src/axiselements.jl
@@ -1,3 +1,6 @@
+"Types accepted by `Plot` for the field `data`."
+abstract type PlotData <: OptionType end
+
 ##############
 # Expression #
 ##############
@@ -10,7 +13,7 @@
 An `Expression` is a string or multiple strings, representing a function, and is
 written in a way LaTeX understands.
 """
-struct Expression <: OptionType
+struct Expression <: PlotData
     fs::Vector{String}
 end
 
@@ -127,7 +130,7 @@ function print_tex(io::IO, coordinate::Coordinate)
     println(io)
 end
 
-struct Coordinates{N}
+struct Coordinates{N} <: PlotData
     data::AbstractVector{Union{Nothing, Coordinate{N}}}
 end
 
@@ -438,7 +441,7 @@ function TableData(x::AbstractVector, y::AbstractVector, z::AbstractMatrix;
     TableData(columns, colnames, length(x), rowsep)
 end
 
-struct Table <: OptionType
+struct Table <: PlotData
     options::Options
     content::Union{TableData, AbstractString}
     Table(options::Options, content::Union{TableData, AbstractString}) =
@@ -512,7 +515,7 @@ end
 
 `Graphics` data simply wraps an image (eg a `.png` file).
 """
-struct Graphics <: OptionType
+struct Graphics <: PlotData
     options::Options
     filename::String
 end
@@ -530,9 +533,6 @@ end
 ########
 # Plot #
 ########
-
-"Types accepted by `Plot` for the field `data`."
-const PlotData = Union{Coordinates, Table, Expression, Graphics}
 
 """
 $(TYPEDEF)


### PR DESCRIPTION
Make `PlotData` an abstract type to allow users to create custom types to be used in `Plot`. For example, I wanted to write the following:
```julia
struct FillBetween <: PGFPlotsX.PlotData
    options::PGFPlotsX.Options
end

function PGFPlotsX.print_tex(io::IO, fb::FillBetween)
    print(io, "fill between ")
    PGFPlotsX.print_options(io, fb.options)
end

push!(PGFPlotsX.CUSTOM_PREAMBLE, raw"\usepgfplotslibrary{fillbetween}")

x = range(-1, 1, length = 51)

@pgf Axis(
    {
        xmajorgrids,
        ymajorgrids,
    },
    Plot(
        {
            "name path=f",
            no_marks,
        },
        Coordinates(x, x)
    ),
    Plot(
        {
            "name path=g",
            no_marks,
        },
        Coordinates(x, 1.2 .* x .+ 1)
    ),
    Plot(
        {
            thick,
            "color=blue",
            "fill=blue",
        },
        FillBetween(
            {
                "of=f and g"
            }
        )
    )
)
```
Before, I wasn't able to do this with a `Plot` object.