### PR TITLE
allow raw strings in plots.

### DIFF
--- a/docs/src/examples/latex.md
+++ b/docs/src/examples/latex.md
@@ -47,3 +47,22 @@ savefigs("annotated-node", ans) # hide
 [\[.pdf\]](annotated-node.pdf), [\[generated .tex\]](annotated-node.tex)
 
 ![](annotated-node.svg)
+
+## [LaTeX code for plot elements](@id latex-plot-elements)
+
+The example below demonstrates how strings can be included as “data” for `Plot`. Specifically, here we name two paths, then use `fill between [of=f and g]` to fill the space between them. This requires the use of the `fillbetween` library for PGFPlots, which we insert in the premable.
+
+```@example pgf
+push!(PGFPlotsX.CUSTOM_PREAMBLE, raw"\usepgfplotslibrary{fillbetween}")
+x = range(-1, 1, length = 51)
+@pgf Axis({ xmajorgrids, ymajorgrids },
+          Plot({ "name path=f", no_marks, }, Coordinates(x, x)),
+          Plot({ "name path=g", no_marks, }, Coordinates(x, 1.2 .* x .+ 1)),
+          Plot({ thick, color = "blue", fill = "blue", opacity = 0.5 },
+               raw"fill between [of=f and g]"))
+savefigs("fillbetween", ans) # hide
+```
+
+[\[.pdf\]](fillbetween.pdf), [\[generated .tex\]](fillbetween.tex)
+
+![](fillbetween.svg)

--- a/docs/src/man/data.md
+++ b/docs/src/man/data.md
@@ -159,3 +159,7 @@ Example:
 julia> print_tex(Graphics("img.png"))
 graphics {img.png}
 ```
+
+## Strings in `Plot`
+
+Strings (technically, all subtypes of `AbstractString`) are also accepted by plots, and will be emitted into LaTeX *as is*. This is mostly useful for using constructs from TikZ that do not have a native representation in this package direcly as LaTeX code. See [this example](@ref latex-plot-elements).

--- a/src/axiselements.jl
+++ b/src/axiselements.jl
@@ -532,7 +532,7 @@ end
 ########
 
 "Types accepted by `Plot` for the field `data`."
-const PlotData = Union{Coordinates, Table, Expression, Graphics}
+const PlotData = Union{Coordinates, Table, Expression, Graphics, AbstractString}
 
 """
 $(TYPEDEF)


### PR DESCRIPTION
This solves the same problem as #171, by allowing strings in plots, following the approach in #169. Example:

```julia
using PGFPlotsX
push!(PGFPlotsX.CUSTOM_PREAMBLE, raw"\usepgfplotslibrary{fillbetween}")
x = range(-1, 1, length = 51)
@pgf Axis({ xmajorgrids, ymajorgrids },
          Plot({ "name path=f", no_marks, }, Coordinates(x, x)),
          Plot({ "name path=g", no_marks, }, Coordinates(x, 1.2 .* x .+ 1)),
          Plot({ thick, "color=blue", "fill=blue" },
               raw"fill between [of=f and g]"))
```
produces
![plot](https://user-images.githubusercontent.com/84122/62514541-cf202c80-b81f-11e9-8d03-bbb09da02b42.png)

# TODO:

- [x] document the feature in the relevant section
- [x] add an example in the gallery