### PR TITLE
Change `filename::String` to `filename::AbstractString`

### DIFF
--- a/docs/src/man/save.md
+++ b/docs/src/man/save.md
@@ -13,7 +13,7 @@ In the REPL, the figure will be exported to a `pdf` and attempted to be opened i
 Figures can be exported to files using
 
 ```jlcon
-pgfsave(filename::String, figure; include_preamble::Bool = true, dpi = 150)
+pgfsave(filename::AbstractString, figure; include_preamble::Bool = true, dpi = 150)
 ```
 
 where the file extension of `filename` determines the file type (can be `pdf`, `svg` or `tex`, or the standalone `tikz` file extensions below), `include_preamble` sets if the preamble should be included in the output (only relevant for `tex` export) and `dpi` determines the dpi of the figure (only relevant for `png` export).

--- a/src/axiselements.jl
+++ b/src/axiselements.jl
@@ -514,7 +514,7 @@ end
 """
 struct Graphics <: OptionType
     options::Options
-    filename::AbstractString
+    filename::String
 end
 
 function Graphics(filename::AbstractString, args::Vararg{PGFOption})

--- a/src/axiselements.jl
+++ b/src/axiselements.jl
@@ -514,10 +514,10 @@ end
 """
 struct Graphics <: OptionType
     options::Options
-    filename::String
+    filename::AbstractString
 end
 
-function Graphics(filename::String, args::Vararg{PGFOption})
+function Graphics(filename::AbstractString, args::Vararg{PGFOption})
     Graphics(dictify(args), filename)
 end
 
@@ -612,7 +612,7 @@ Plot3Inc(options::Options, data::PlotData, trailing...) =
 Plot3Inc(data::PlotData, trailing...) =
     Plot(true, true, Options(), data, trailing)
 
-function save(filename::String, plot::Plot; kwargs...)
+function save(filename::AbstractString, plot::Plot; kwargs...)
     save(filename, Axis(plot); kwargs...)
 end
 

--- a/src/axislike.jl
+++ b/src/axislike.jl
@@ -40,7 +40,7 @@ function print_tex(io::IO, axislike::T) where {T <: AxisLike}
     println(io, "\\end{", name, "}")
 end
 
-function save(filename::String, axislike::AxisLike; kwargs...)
+function save(filename::AbstractString, axislike::AxisLike; kwargs...)
     save(filename, TikzPicture(axislike); kwargs...)
 end
 

--- a/src/build.jl
+++ b/src/build.jl
@@ -25,7 +25,7 @@ Temporary files (`.aux`, `.log`) are cleaned up.
     Changing the working directory is required because of external tools like
     `gnuplot`, which don't respect `--output-directory`.
 """
-function run_latex_once(filename::String, eng::LaTeXEngine, flags)
+function run_latex_once(filename::AbstractString, eng::LaTeXEngine, flags)
     dir, file = splitdir(filename)
     cmd = `$(_engine_cmd(eng)) $flags $file`
     succ = cd(() -> success(cmd), dir)
@@ -34,7 +34,7 @@ function run_latex_once(filename::String, eng::LaTeXEngine, flags)
     succ, log, cmd
 end
 
-function rm_tmpfiles(filename::String)
+function rm_tmpfiles(filename::AbstractString)
     logfile = _replace_fileext(filename, ".log")
     auxfile = _replace_fileext(filename, ".aux")
     rm(logfile; force = true)

--- a/src/tikzdocument.jl
+++ b/src/tikzdocument.jl
@@ -63,7 +63,7 @@ Keywords specify options, some specific to some output formats.
 
 `pgfsave` is an alias which is exported.
 """
-function save(filename::String, td::TikzDocument;
+function save(filename::AbstractString, td::TikzDocument;
               include_preamble::Bool = true,
               latex_engine = latexengine(),
               buildflags = vcat(DEFAULT_FLAGS, CUSTOM_FLAGS),
@@ -99,7 +99,7 @@ end
 const pgfsave = save
 
 # TeX
-function savetex(filename::String, td::TikzDocument;
+function savetex(filename::AbstractString, td::TikzDocument;
                  include_preamble::Bool = true)
     open(filename, "w") do io
         savetex(io, td; include_preamble = include_preamble)
@@ -152,7 +152,7 @@ end
 
 _HAS_WARNED_SHELL_ESCAPE = false
 
-function savepdf(filename::String, td::TikzDocument;
+function savepdf(filename::AbstractString, td::TikzDocument;
                  latex_engine = latexengine(),
                  buildflags = vcat(DEFAULT_FLAGS, CUSTOM_FLAGS),
                  run_count = 0, tmp = tempname())
@@ -260,7 +260,7 @@ if HAVE_PDFTOSVG
     `filename` with the extension (if any) replaced by `".pdf"`. This overwrites
     an existing PDF file with the same name.
     """
-    function savesvg(filename::String, td::TikzDocument;
+    function savesvg(filename::AbstractString, td::TikzDocument;
                      latex_engine = latexengine(),
                      buildflags = vcat(DEFAULT_FLAGS, CUSTOM_FLAGS),
                      keep_pdf = false)
@@ -310,7 +310,7 @@ if HAVE_PDFTOSVG
 end
 
 if HAVE_PDFTOPPM
-    function savepng(filename::String, td::TikzDocument;
+    function savepng(filename::AbstractString, td::TikzDocument;
                      latex_engine = latexengine(),
                      buildflags = vcat(DEFAULT_FLAGS, CUSTOM_FLAGS),
                      dpi::Int = 150)

--- a/src/tikzpicture.jl
+++ b/src/tikzpicture.jl
@@ -29,6 +29,6 @@ function print_tex(io::IO, tp::TikzPicture)
     println(io, "\\end{tikzpicture}")
 end
 
-function save(filename::String, tp::TikzPicture; kwargs...)
+function save(filename::AbstractString, tp::TikzPicture; kwargs...)
     save(filename, TikzDocument(tp); kwargs...)
 end

--- a/test/test_build.jl
+++ b/test/test_build.jl
@@ -59,9 +59,6 @@ end
             pgfsave("$tmp.tex", a)
             @test is_tex_document("$tmp.tex")
             println(read("$tmp.tex", String))
-            # test with filename::String{SubString}
-            pgfsave(split("foo|$tmp-2.tex", '|')[2], a)
-            @test is_tex_document("$tmp-2.tex")
             if PGFPlotsX.HAVE_PDFTOPPM
                 pgfsave("$tmp.png", a)
                 @test is_png_file("$tmp.png")
@@ -78,6 +75,9 @@ end
             @test is_pdf_file("$tmp.pdf")
             pgfsave("$tmp.tikz", a)
             @test is_tikz_standalone("$tmp.tikz")
+            # test with filename::String{SubString}
+            pgfsave(split("foo|$tmp-2.pdf", '|')[2], a)
+            @test is_pdf_file("$tmp-2.pdf")
 
             let tikz_lines = readlines("$tmp.tikz")
                 @test occursin(r"^\\begin{tikzpicture}.*", tikz_lines[1])

--- a/test/test_build.jl
+++ b/test/test_build.jl
@@ -59,6 +59,9 @@ end
             pgfsave("$tmp.tex", a)
             @test is_tex_document("$tmp.tex")
             println(read("$tmp.tex", String))
+            # test with filename::String{SubString}
+            pgfsave(split("foo|$tmp-2.tex", '|')[2], a)
+            @test is_tex_document("$tmp-2.tex")
             if PGFPlotsX.HAVE_PDFTOPPM
                 pgfsave("$tmp.png", a)
                 @test is_png_file("$tmp.png")


### PR DESCRIPTION
This is a tiny change which widens the type space of `filename`. I ran into the issues multiple times that `split` creates strings of type `SubString{String}` which cannot be passed as `filename` in e.g. `pgfsave`.