### PR TITLE
Fix VLine and HLine for log axis.

### DIFF
--- a/src/axiselements.jl
+++ b/src/axiselements.jl
@@ -699,7 +699,7 @@ function print_tex(io::IO, vline::VLine)
     @unpack options, x = vline
     print(io, "\\draw")
     print_options(io, options; newline = false)
-    println(io, "($(x),\\pgfkeysvalueof{/pgfplots/ymin})--($(x),\\pgfkeysvalueof{/pgfplots/ymax});")
+    println(io, "({axis cs:$(x),0}|-{rel axis cs:0,1}) -- ({axis cs:$(x),0}|-{rel axis cs:0,0});")
 end
 
 struct HLine
@@ -718,5 +718,5 @@ function print_tex(io::IO, hline::HLine)
     @unpack options, y = hline
     print(io, "\\draw")
     print_options(io, options; newline = false)
-    println(io, "(\\pgfkeysvalueof{/pgfplots/xmin},$(y))--(\\pgfkeysvalueof{/pgfplots/xmax},$(y));")
+    println(io, "({rel axis cs:1,0}|-{axis cs:0,$(y)}) -- ({rel axis cs:0,0}|-{axis cs:0,$(y)});")
 end

--- a/test/test_elements.jl
+++ b/test/test_elements.jl
@@ -205,9 +205,9 @@ end
 
 @testset "vertical and horizontal lines" begin
     @test repr_tex((@pgf VLine({blue}, 9))) ==
-        "\\draw[blue] (9,\\pgfkeysvalueof{/pgfplots/ymin})--(9,\\pgfkeysvalueof{/pgfplots/ymax});\n"
+        "\\draw[blue] ({axis cs:9,0}|-{rel axis cs:0,1}) -- ({axis cs:9,0}|-{rel axis cs:0,0});\n"
     @test repr_tex((@pgf HLine({dashed}, 4.0))) ==
-        "\\draw[dashed] (\\pgfkeysvalueof{/pgfplots/xmin},4.0)--(\\pgfkeysvalueof{/pgfplots/xmax},4.0);\n"
+        "\\draw[dashed] ({rel axis cs:1,0}|-{axis cs:0,4.0}) -- ({rel axis cs:0,0}|-{axis cs:0,4.0});\n"
 end
 
 @testset "colors" begin


### PR DESCRIPTION
Fixes #193 
```julia
julia> @pgf ax = Axis({ymode="log", xmode="log"},
           PlotInc(
               Expression("x^2"),
           ),
           VLine(1.),
           HLine(5.),
           )

```

![demo](https://user-images.githubusercontent.com/16306680/69363773-fe509180-0c88-11ea-8ee9-6a45612bcc39.png)

and it still works fine with linear axes:
![demo2](https://user-images.githubusercontent.com/16306680/69363851-22ac6e00-0c89-11ea-82c7-3672685cf995.png)
