### PR TITLE
prettify printing options

### DIFF
--- a/src/options.jl
+++ b/src/options.jl
@@ -125,9 +125,10 @@ function print_options(io::IO, options::Options; newline = true)
     if isempty(dict)
         print_empty && print(io, "[]")
     else
-        print(io, "[")
+        println(io, "[")
         print_opt(io, options)
-        print(io, "]")
+        println(io)
+        print(io, add_indent("]"))
     end
     newline ? println(io) : print(io, " ")
 end
@@ -166,14 +167,14 @@ function print_opt(io::IO, options::Options)
     replace_underline(x) = x
     replace_underline(x::Union{String, Symbol}) = replace(string(x), "_" => " ")
     for (i, (k, v)) in enumerate(dict)
-        print_opt(io, replace_underline(k))
+        print_opt(io, add_indent(replace_underline(k)))
         if v != nothing
             print(io, "={")
             print_opt(io, v)
             print(io, "}")
         end
         if i != length(dict)
-          print(io, ", ")
+          println(io, ",")
         end
     end
 end


### PR DESCRIPTION
Before:
```julia
julia> p = @pgf Axis(
           {
               view = (0, 90),
               colorbar,
               "colormap/jet", shader = "flat",
           },
           Plot3(
               {
                   surf,
                   "mesh/cols" = 2,
                   point_meta = "explicit",
               },
               Table({x_index = 0, y_index = 1, meta_index = 2}, [1, 2, 3, 4], [1, 2, 3, 4], [1, 3, 2, 3])
           )
       );

julia> print_tex(p)
\begin{axis}[view={0}{90}, colorbar, colormap/jet, shader={flat}]
    \addplot3[surf, mesh/cols={2}, point meta={explicit}]
        table[row sep={\\}, x index={0}, y index={1}, meta index={2}]
        {
            \\
            1  1  1  \\
            2  2  3  \\
            3  3  2  \\
            4  4  3  \\
        }
        ;
\end{axis}
```
After:
```julia
julia> print_tex(p)
\begin{axis}[
    view={0}{90},
    colorbar,
    colormap/jet,
    shader={flat}
    ]
    \addplot3[
        surf,
        mesh/cols={2},
        point meta={explicit}
        ]
        table[
            row sep={\\},
            x index={0},
            y index={1},
            meta index={2}
            ]
        {
            \\
            1  1  1  \\
            2  2  3  \\
            3  3  2  \\
            4  4  3  \\
        }
        ;
\end{axis}
```