### PR TITLE
improve insertion of pgf{theme...,}

### DIFF
--- a/test/test_options.jl
+++ b/test/test_options.jl
@@ -17,7 +17,7 @@ end
     opt = @pgf { xmax = a + b, title = "42", justkey, theme... }
     @test opt["color"] == "white"
     @test repr_tex(opt) == repr_tex(Options("xmax" => 3, "title" => "42", "justkey" => nothing,
-                                            color="white"))
+                                            color => "white"))
     f(x...) = tuple(x...)
     y = @pgf f({ look, we, are = f(1, 2, 3), nesting = { stuff = 9 }})
     @test length(y) == 1

--- a/test/test_options.jl
+++ b/test/test_options.jl
@@ -17,7 +17,7 @@ end
     opt = @pgf { xmax = a + b, title = "42", justkey, theme... }
     @test opt["color"] == "white"
     @test repr_tex(opt) == repr_tex(Options("xmax" => 3, "title" => "42", "justkey" => nothing,
-                                            color => "white"))
+                                            "color" => "white"))
     f(x...) = tuple(x...)
     y = @pgf f({ look, we, are = f(1, 2, 3), nesting = { stuff = 9 }})
     @test length(y) == 1

--- a/test/test_options.jl
+++ b/test/test_options.jl
@@ -14,9 +14,10 @@ end
     a = 1
     b = 2
     theme = @pgf {color = "white"}
-    @test repr_tex(@pgf { xmax = a + b, title = "42", justkey, theme... }) ==
-        repr_tex(Options("xmax" => 3, "title" => "42", "justkey" => nothing,
-                         @pgf { color="white" } => nothing))
+    opt = @pgf { xmax = a + b, title = "42", justkey, theme... }
+    @test opt["color"] == "white"
+    @test repr_tex(opt) == repr_tex(Options("xmax" => 3, "title" => "42", "justkey" => nothing,
+                                            color="white"))
     f(x...) = tuple(x...)
     y = @pgf f({ look, we, are = f(1, 2, 3), nesting = { stuff = 9 }})
     @test length(y) == 1


### PR DESCRIPTION
instead of inserting a nested Option with a `nothing` value
we now instead insert the keys directly into the Options being
created. This means we can now access keys in the splatted "theme"
just like if it was written inline