### PR TITLE
Document the Options constructor as part of the exposed API.

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,6 +1,6 @@
 using Documenter, PGFPlotsX
 PGFPlotsX.latexengine!(PGFPlotsX.LUALATEX)
-
+DocMeta.setdocmeta!(PGFPlotsX, :DocTestSetup, :(using PGFPlotsX); recursive=true)
 using Contour, Colors, DataFrames, Distributions
 
 makedocs(

--- a/docs/src/man/internals.md
+++ b/docs/src/man/internals.md
@@ -10,7 +10,6 @@ end
 print_tex
 PGFPlotsX.print_indent
 PGFPlotsX.expand_scanlines
-PGFPlotsX.Options
 PGFPlotsX.CUSTOM_PREAMBLE_PATH
 PGFPlotsX.DEFAULT_PREAMBLE
 ```

--- a/docs/src/man/options.md
+++ b/docs/src/man/options.md
@@ -179,3 +179,9 @@ Empty options are not printed by default, but printing `[]` can be useful in som
 ```julia
 @pgf Plot({}, ...)
 ```
+
+## The `PGFPlotsX.Options` constructor
+
+```@docs
+PGFPlotsX.Options
+```

--- a/src/options.jl
+++ b/src/options.jl
@@ -3,6 +3,10 @@ struct Options
     print_empty::Bool
 end
 
+function Base.show(io::IO, options::Options)
+    print_options(io, options; newline = false)
+end
+
 # Wrapper to wrap arguments in the `@pgf {theme...,}` syntax to
 # insert all entries in `theme` into the Option
 struct MergeEntry
@@ -10,12 +14,20 @@ struct MergeEntry
 end
 
 """
-    $SIGNATURES
+    $(SIGNATURES)
 
 Options passed to PGFPlots for various structures (`table`, `plot`, etc).
 
-Contents emitted in `key = value` form, or `key` when `value ≡ nothing`. Also
-see the [`@pgf`](@ref) convenience macro.
+Contents emitted in `key = value` form, or `key` when `value ≡ nothing`. Example:
+
+```jldoctest
+julia> PGFPlotsX.Options(:color => "red", :only_marks => nothing)
+[color={red}, only marks]
+```
+
+The constuctor is not exported but part of the API, for use in packages that depend on
+PGFPlotsX, or code producing complicated plots. It is recommended that the [`@pgf`](@ref)
+macro is used in scripts and interactive code.
 
 When `print_empty = false` (the default), empty options are not printed. Use
 `print_empty = true` to force printing a `[]` in this case.

--- a/src/options.jl
+++ b/src/options.jl
@@ -3,7 +3,7 @@ struct Options
     print_empty::Bool
 end
 
-function Base.show(io::IO, options::Options)
+function Base.show(io::IO, ::MIME"text/plain", options::Options)
     print_options(io, options; newline = false)
 end
 


### PR DESCRIPTION
Incidentally, make options it print in LaTeX format.

Follow-up to #231, see discussion in #230.