### PR TITLE
Add comment with recommended preamble for standalone tikzpictures

### DIFF
--- a/src/tikzdocument.jl
+++ b/src/tikzdocument.jl
@@ -140,6 +140,11 @@ function print_tex(io::IO, td::TikzDocument; include_preamble::Bool = true)
             print_tex(io, preamble_line, td)
         end
         println(io, "\\begin{document}")
+    else
+        print_tex(io,"% Recommended preamble:")
+        for preamble_line in preamble
+            print_tex(io,replace(preamble_line,r"^"m => s"% "),td)
+        end
     end
     for element in td.elements
         print_tex(io, element, td)

--- a/test/test_build.jl
+++ b/test/test_build.jl
@@ -20,8 +20,17 @@ is_pdf_file(filename) = is_file_starting_with(filename, b"%PDF")
 is_tex_document(filename) =     # may have a \Require in the first line
     is_file_starting_with(filename, r"\\documentclass\[tikz\]{standalone}", 2)
 
-is_tikz_standalone(filename) =
-    is_file_starting_with(filename, r"\\begin{tikzpicture}")
+function is_tikz_standalone(filename)
+    if !isfile(filename)
+        return false
+    end
+    s = read(filename,String)
+    m = match(r"^([^%].*$)"m,s) # First non-commented non-empty line
+    if isnothing(m)
+        return false
+    end
+    return occursin(r"\\begin{tikzpicture}",m.captures[1])
+end
 
 is_svg_file(filename) = is_file_starting_with(filename, r"<svg .*>", 2)
 
@@ -80,7 +89,6 @@ end
             @test is_pdf_file("$tmp-2.pdf")
 
             let tikz_lines = readlines("$tmp.tikz")
-                @test occursin(r"^\\begin{tikzpicture}.*", tikz_lines[1])
                 last_line = findlast(!isempty, tikz_lines)
                 @test strip(tikz_lines[last_line]) == "\\end{tikzpicture}"
             end


### PR DESCRIPTION
Adds a commented-out preamble before standalone tikzpictures.
This necessitated a change in definition of the `is_tikz_standalone` test, skipping commented lines.

Close #256