### PR TITLE
Handle missing values for `Coordinates`

### DIFF
--- a/src/axiselements.jl
+++ b/src/axiselements.jl
@@ -132,7 +132,7 @@ struct Coordinates{N}
 end
 
 coordinate_or_nothing(data, args...) =
-    all(x -> x isa AbstractString || isfinite(x), data) ? Coordinate(data, args...) : nothing
+    all(x -> x isa AbstractString || isfinite(x)===true, data) ? Coordinate(data, args...) : nothing
 
 """
     $SIGNATURES
@@ -170,7 +170,7 @@ function Coordinates(itr)
     ensure_c(::Union{Nothing, Tuple{}}) = nothing
     ensure_c(c::Coordinate{N}) where N = (check_N(N); c)
     ensure_c(x) = throw(ArgumentError("Can't interpret $x as a coordinate."))
-    function ensure_c(data::NTuple{N, CoordinateType}) where N
+    function ensure_c(data::NTuple{N, Union{CoordinateType, Missing}}) where N
         check_N(N)
         coordinate_or_nothing(data)
     end

--- a/src/axiselements.jl
+++ b/src/axiselements.jl
@@ -175,7 +175,7 @@ function Coordinates(itr)
         coordinate_or_nothing(data)
     end
     data = [ensure_c(data) for data in itr]
-    @argcheck common_N ≠ 0 || "Could not determine dimension from coordinates"
+    @argcheck common_N ≠ 0 "Could not determine dimension from coordinates"
     Coordinates{common_N}(data)
 end
 

--- a/test/test_elements.jl
+++ b/test/test_elements.jl
@@ -69,6 +69,10 @@ end
             Coordinates([1.0, 2.0], [3.0, 4.0], yerror = [0.3, 0.4]).data
     end
 
+    # missing values
+    @test Coordinates([1,2], [3,missing]).data == Coordinates([(1,3), nothing]).data
+    @test Coordinates([(1,3), (2,missing)]).data == Coordinates([(1,3), nothing]).data
+
     # meta printing
     @test squashed_repr_tex(Coordinates([1], [1]; meta = [RGB(0.1, 0.2, 0.3)])) ==
         "coordinates {\n(1,1) [rgb=0.1,0.2,0.3]\n}"


### PR DESCRIPTION
This PR makes `Coordinates` handle `missing`s:

```Julia
julia> Plot(Coordinates([1,2,3], [4,5,missing]))

julia> Plot(Coordinates([(1,4), (2,5), (3,missing)]))
```