### PR TITLE
Add `copy` method for `tikzdocument`

### DIFF
--- a/src/tikzdocument.jl
+++ b/src/tikzdocument.jl
@@ -25,6 +25,8 @@ end
 Base.push!(t::TikzDocument, args...; kwargs...) = (push!(t.elements, args...; kwargs...); t)
 Base.append!(t::TikzDocument, args...; kwargs...) = (append!(t.elements, args...; kwargs...); t)
 
+Base.copy(t::TikzDocument) = deepcopy(t)
+
 """
     $SIGNATURES
 


### PR DESCRIPTION
Added a `copy` method for `tikzdocument`

closes PR #320.