### PR TITLE
Add "col sep" option to Table and TableData

### DIFF
--- a/src/options.jl
+++ b/src/options.jl
@@ -59,6 +59,8 @@ Base.getindex(o::Options, args...; kwargs...) = getindex(o.dict, args...; kwargs
 Base.setindex!(o::Options, args...; kwargs...) = (setindex!(o.dict, args...; kwargs...); o)
 Base.delete!(o::Options, args...; kwargs...) = (delete!(o.dict, args...; kwargs...); o)
 Base.haskey(o::Options, args...; kwargs...) = haskey(o.dict, args...; kwargs...)
+Base.get(o::Options, key) = o.dict[key]
+Base.get(o::Options, key, default) = haskey(o.dict, key) ? o.dict[key] : default
 
 Base.copy(options::Options) = deepcopy(options)
 

--- a/test/test_options.jl
+++ b/test/test_options.jl
@@ -34,7 +34,7 @@ end
 
 @testset "pgf empty" begin
     @test squashed_repr_tex(@pgf Plot({}, Table("x" => [1,2,3]))) ==
-        "\\addplot[]\ntable[row sep={\\\\}]\n{\nx \\\\\n1 \\\\\n2 \\\\\n3 \\\\\n}\n;" # note []
+        "\\addplot[]\ntable[row sep={\\\\}, col sep={space}]\n{\nx\\\\\n1\\\\\n2\\\\\n3\\\\\n}\n;" # note []
 end
 
 @testset "nested options vector" begin


### PR DESCRIPTION
This PR adds the possibility to pass the `col sep` option to `Table` and subsequently to `TableData` so that the underlying serialisation logic uses the correct character to separate columns.
It's also a workaround for https://github.com/KristofferC/PGFPlotsX.jl/issues/333 where `DateTime` instances cause trouble due to the way they are serialised -> a `space` is between the date and time, which introduces an unexpected column with the default `space` column separator.

The `col sep` option takes the usual PGF keywords from a dictionary:

```julia
const COLSEPARATORMAP = Dict("space" => " ", "tab" => "\t", "comma" => ",", "semicolon" => ";", "colon" => ":", "ampersand" => "&")
```

Note that `braces` is also a valid keyword but not implemented yet. I have not looked it up but I assume that it requires to put each column between braces: `{}`.

The default behaviour is not altered (although the leading `space` is now removed before the line-separator to keep the logic consistent for all separators):

```julia
julia> print_tex(@pgf Table("x" => [1,2,3], "y" => [4,5,6]))
table[row sep={\\}, col sep={space}]
{
    x y\\
    1 4\\
    2 5\\
    3 6\\
}
```

and here is an example using `"ampersand"`:

```julia
julia> print_tex(@pgf Table({col_sep="ampersand"}, "x" => [1,2,3], "y" => [4,5,6]))
table[row sep={\\}, col sep={ampersand}]
{
    x&y\\
    1&4\\
    2&5\\
    3&6\\
}
```

Arbitrary strings are accepted as well:

```julia
julia> print_tex(@pgf Table({col_sep = "|"}, "x" => [1,2,3], "y" => [4,5,6]))
table[row sep={\\}, col sep={|}]
{
    x|y\\
    1|4\\
    2|5\\
    3|6\\
}
```

The PR is not finished yet and I am also unsure about the approach since I somehow need to propagate the column separator option from `Table` to `TableData` and they way I do it is not very nice `;)`

Also the tests with the table instance comparisons are currently failing, see below. But let's first see if this idea is going anywhere.

```
Test Summary:                            | Pass  Total  Time
coordinates and convenience constructors |   15     15  2.8s
tables: Error During Test at /Users/tamasgal/Dev/PGFPlotsX.jl/test/test_elements.jl:90
  Test threw exception
  Expression: Table(; a = 1:10, b = 11:20) ≅ table_named_noopt
  DimensionMismatch: number of rows of each array must match (got (1, 10))
  Stacktrace:
    [1] _typed_hcat(::Type{Any}, A::Tuple{Matrix{Any}, UnitRange{Int64}})
      @ Base ./abstractarray.jl:1691
    [2] typed_hcat
      @ ./abstractarray.jl:1670 [inlined]
    [3] hcat(::Matrix{Any}, ::UnitRange{Int64})
      @ Base ./abstractarray.jl:1680
    [4] _mapreduce(f::typeof(identity), op::typeof(hcat), ::IndexLinear, A::Vector{Any})
      @ Base ./reduce.jl:440
    [5] _mapreduce_dim(f::Function, op::Function, ::Base._InitialValue, A::Vector{Any}, ::Colon)
      @ Base ./reducedim.jl:337
    [6] mapreduce
      @ ./reducedim.jl:329 [inlined]
    [7] reduce(op::Function, A::Vector{Any})
      @ Base ./reducedim.jl:378
    [8] TableData(name_column_pairs::Vector{Pair{Symbol}}; scanlines::Int64, rowsep::Bool, colsep::String)
      @ PGFPlotsX ~/Dev/PGFPlotsX.jl/src/axiselements.jl:412
    [9] TableData(name_column_pairs::Vector{Pair{Symbol}})
      @ PGFPlotsX ~/Dev/PGFPlotsX.jl/src/axiselements.jl:410
   [10] TableData(; named_columns::@Kwargs{rowsep::Bool, colsep::String, a::UnitRange{Int64}, b::UnitRange{Int64}})
      @ PGFPlotsX ~/Dev/PGFPlotsX.jl/src/axiselements.jl:436
   [11] Table(::Options; kwargs::@Kwargs{a::UnitRange{Int64}, b::UnitRange{Int64}})
      @ PGFPlotsX ~/Dev/PGFPlotsX.jl/src/axiselements.jl:482
   [12] Table
      @ ~/Dev/PGFPlotsX.jl/src/axiselements.jl:482 [inlined]
   [13] #Table#53
      @ ~/Dev/PGFPlotsX.jl/src/axiselements.jl:485 [inlined]
   [14] macro expansion
      @ ~/.julia/juliaup/julia-1.11.1+0.aarch64.apple.darwin14/share/julia/stdlib/v1.11/Test/src/Test.jl:676 [inlined]
   [15] macro expansion
      @ ~/Dev/PGFPlotsX.jl/test/test_elements.jl:90 [inlined]
   [16] macro expansion
      @ ~/.julia/juliaup/julia-1.11.1+0.aarch64.apple.darwin14/share/julia/stdlib/v1.11/Test/src/Test.jl:1700 [inlined]
   [17] top-level scope
      @ ~/Dev/PGFPlotsX.jl/test/test_elements.jl:83
tables: Error During Test at /Users/tamasgal/Dev/PGFPlotsX.jl/test/test_elements.jl:118
  Test threw exception
  Expression: squashed_repr_tex(Table(PGFPlotsX.Options(), [1 NaN; -Inf 4.0], ["xx", "yy"], [1])) == "table[row sep={\\\\}]\n{\nxx yy \\\\\n1.0 nan \\\\\n\\\\\n-inf 4.0 \\\\\n}"
  MethodError: no method matching TableData(::Matrix{Float64}, ::Vector{String}, ::Vector{Int64}; rowsep::Bool, colsep::String)
  This method may not support any kwargs.
```